### PR TITLE
:package: polars macOS universal2 릴리스 빌드 수정

### DIFF
--- a/.github/workflows/polars-release.yml
+++ b/.github/workflows/polars-release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           working-directory: polars
+          maturin-version: v1.13.1
           target: ${{ matrix.target }}
           manylinux: "2014"
           sccache: "true"
@@ -92,10 +93,13 @@ jobs:
           targets: x86_64-apple-darwin
       - name: Build universal2 wheel
         uses: PyO3/maturin-action@v1
+        env:
+          ARCHFLAGS: "-arch x86_64 -arch arm64"
         with:
           working-directory: polars
+          maturin-version: v1.13.1
           sccache: "true"
-          args: --release --out dist --universal2
+          args: --release --out dist
 
       - name: Check artifact contents
         run: python polars/scripts/check_artifacts.py polars/dist
@@ -134,6 +138,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           working-directory: polars
+          maturin-version: v1.13.1
           target: x86_64-pc-windows-msvc
           sccache: "true"
           args: --release --out dist
@@ -173,6 +178,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           working-directory: polars
+          maturin-version: v1.13.1
           command: sdist
           args: --out dist
 


### PR DESCRIPTION
## 요약
- macOS 릴리스 빌드에서 지원되지 않는 `--universal2` 인자를 제거
- `ARCHFLAGS="-arch x86_64 -arch arm64"` 기반으로 universal2 wheel 빌드
- 릴리스 워크플로우에서 `maturin` 버전을 `v1.13.1`로 고정

## 배경
- `build-macos` job이 `maturin build --release --out dist --universal2` 실행 시 `unexpected argument `--universal2` found`로 실패하고 있었습니다.

## 검증
- 로컬에서 workflow diff 및 `git diff --check` 확인
- macOS GitHub Actions 재실행 필요