### PR TITLE
♻️ GitHub Actions Node 24 경고 정리

### DIFF
--- a/.github/workflows/polars-ci.yml
+++ b/.github/workflows/polars-ci.yml
@@ -24,11 +24,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.10"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.0.0
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Sync polars dependencies

--- a/.github/workflows/polars-ci.yml
+++ b/.github/workflows/polars-ci.yml
@@ -24,8 +24,8 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - uses: astral-sh/setup-uv@v8.0.0

--- a/.github/workflows/polars-release.yml
+++ b/.github/workflows/polars-release.yml
@@ -11,21 +11,23 @@ permissions:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64
             artifact: wheels-linux-x86_64
+            runner: ubuntu-latest
           - target: aarch64
             artifact: wheels-linux-aarch64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - uses: astral-sh/setup-uv@v8.0.0
@@ -56,28 +58,21 @@ jobs:
           )"
           uv run --isolated --python 3.10 --with "$wheel" python polars/scripts/smoke_import.py
 
-      - uses: docker/setup-qemu-action@v4.0.0
-        if: matrix.target == 'aarch64'
-        with:
-          platforms: arm64
-
       - name: Smoke test aarch64 wheel
         if: matrix.target == 'aarch64'
         run: |
-          docker run --rm --platform linux/arm64/v8 \
-            -v "$PWD:/work" \
-            -w /work \
-            ubuntu:22.04 \
-            bash -lc '
-              set -euo pipefail
-              apt-get update
-              apt-get install -y --no-install-recommends python3 python3-pip
-              pip3 install -U pip
-              pip3 install polars/dist/*.whl --force-reinstall
-              python3 polars/scripts/smoke_import.py
-            '
+          wheel="$(python - <<'PY'
+          from pathlib import Path
 
-      - uses: actions/upload-artifact@v7.0.1
+          wheels = sorted(Path('polars/dist').glob('*.whl'))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected exactly one wheel, found {len(wheels)}")
+          print(wheels[0].resolve().as_posix())
+          PY
+          )"
+          uv run --isolated --python 3.10 --with "$wheel" python polars/scripts/smoke_import.py
+
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: polars/dist/*
@@ -88,8 +83,8 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - uses: astral-sh/setup-uv@v8.0.0
@@ -122,7 +117,7 @@ jobs:
           )"
           uv run --isolated --python 3.10 --with "$wheel" python polars/scripts/smoke_import.py
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-universal2
           path: polars/dist/*
@@ -133,8 +128,8 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           architecture: "x64"
@@ -164,7 +159,7 @@ jobs:
           )"
           uv run --isolated --python 3.10 --with "$wheel" python polars/scripts/smoke_import.py
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-x64
           path: polars/dist/*
@@ -175,8 +170,8 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Build sdist
@@ -190,7 +185,7 @@ jobs:
       - name: Check artifact contents
         run: python polars/scripts/check_artifacts.py polars/dist
 
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: polars/dist/*
@@ -203,7 +198,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8.0.1
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
@@ -221,7 +216,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8.0.1
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/polars-release.yml
+++ b/.github/workflows/polars-release.yml
@@ -24,11 +24,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.10"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.0.0
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -56,23 +56,28 @@ jobs:
           )"
           uv run --isolated --python 3.10 --with "$wheel" python polars/scripts/smoke_import.py
 
+      - uses: docker/setup-qemu-action@v4.0.0
+        if: matrix.target == 'aarch64'
+        with:
+          platforms: arm64
+
       - name: Smoke test aarch64 wheel
         if: matrix.target == 'aarch64'
-        uses: uraimo/run-on-arch-action@v2
-        with:
-          arch: aarch64
-          distro: ubuntu22.04
-          githubToken: ${{ github.token }}
-          install: |
-            apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
-            pip3 install -U pip
-          run: |
-            set -e
-            pip3 install polars/dist/*.whl --force-reinstall
-            python3 polars/scripts/smoke_import.py
+        run: |
+          docker run --rm --platform linux/arm64/v8 \
+            -v "$PWD:/work" \
+            -w /work \
+            ubuntu:22.04 \
+            bash -lc '
+              set -euo pipefail
+              apt-get update
+              apt-get install -y --no-install-recommends python3 python3-pip
+              pip3 install -U pip
+              pip3 install polars/dist/*.whl --force-reinstall
+              python3 polars/scripts/smoke_import.py
+            '
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: polars/dist/*
@@ -83,11 +88,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.10"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.0.0
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-darwin
@@ -117,7 +122,7 @@ jobs:
           )"
           uv run --isolated --python 3.10 --with "$wheel" python polars/scripts/smoke_import.py
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: wheels-macos-universal2
           path: polars/dist/*
@@ -128,12 +133,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.10"
           architecture: "x64"
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.0.0
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -159,7 +164,7 @@ jobs:
           )"
           uv run --isolated --python 3.10 --with "$wheel" python polars/scripts/smoke_import.py
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: wheels-windows-x64
           path: polars/dist/*
@@ -170,8 +175,8 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.10"
       - name: Build sdist
@@ -185,7 +190,7 @@ jobs:
       - name: Check artifact contents
         run: python polars/scripts/check_artifacts.py polars/dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: wheels-sdist
           path: polars/dist/*
@@ -198,7 +203,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with:
           path: dist
           merge-multiple: true
@@ -216,7 +221,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8.0.1
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
## 요약
- CI/Release 워크플로우의 GitHub Actions 버전을 Node 24 대응 버전으로 업그레이드
- aarch64 smoke test에서 `uraimo/run-on-arch-action` 의존성을 제거
- `docker/setup-qemu-action@v4` + `docker run --platform linux/arm64/v8` 조합으로 대체

## 배경
- 기존 릴리스 run에서 Node 20 deprecation 경고가 반복되고 있었습니다.
- `uraimo/run-on-arch-action` 최신 `v3.0.1`도 아직 `node20` 기반이라 major 업그레이드만으로는 경고를 없앨 수 없었습니다.

## 변경 사항
- `actions/checkout` -> `v6.0.2`
- `actions/setup-python` -> `v6.2.0`
- `astral-sh/setup-uv` -> `v8.0.0`
- `actions/upload-artifact` -> `v7.0.1`
- `actions/download-artifact` -> `v8.0.1`
- `docker/setup-qemu-action` -> `v4.0.0`

## 검증
- 로컬에서 두 workflow YAML 파싱 확인
- `git diff --check` 확인
- 실제 경고 제거 여부와 aarch64 smoke는 GitHub Actions 재실행으로 확인 필요

## 참고
- https://github.com/actions/checkout/releases/tag/v6.0.2
- https://github.com/actions/setup-python/releases/tag/v6.2.0
- https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0
- https://github.com/actions/upload-artifact/releases/tag/v7.0.1
- https://github.com/actions/download-artifact/releases/tag/v8.0.1
- https://github.com/docker/setup-qemu-action/releases/tag/v4.0.0