### PR TITLE
⚡ Optimize aligned signal calculations

### DIFF
--- a/core/src/indicators/ema.rs
+++ b/core/src/indicators/ema.rs
@@ -1,3 +1,7 @@
+/// Computes an exponential moving average over a dense `f64` series.
+///
+/// The returned vector keeps the same length as the input and emits `None`
+/// until the first full `period` window has been observed.
 pub fn ema(data: &[f64], period: usize) -> Vec<Option<f64>> {
     let mut result = vec![None; data.len()];
 
@@ -18,38 +22,44 @@ pub fn ema(data: &[f64], period: usize) -> Vec<Option<f64>> {
     result
 }
 
+/// Computes an EMA over an optional series while preserving original alignment.
+///
+/// The EMA state advances only on `Some(f64)` values, so interior `None` holes
+/// are skipped safely. This lets callers avoid compacting a sparse aligned
+/// series into a temporary dense vector before applying `ema`.
 pub(crate) fn ema_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let mut result = vec![None; data.len()];
-    let Some(first_valid_idx) = data.iter().position(|value| value.is_some()) else {
-        return result;
-    };
-
-    let valid_len = data.len() - first_valid_idx;
-    if period == 0 || valid_len < period {
+    if period == 0 {
         return result;
     }
 
-    let first_signal_idx = first_valid_idx + period - 1;
     let alpha = 2.0 / (period as f64 + 1.0);
-    let mut ema = mean_window(data, first_valid_idx, period);
+    let mut seeded_count = 0usize;
+    let mut seed_sum = 0.0;
+    let mut ema = None;
 
-    result[first_signal_idx] = Some(ema);
+    for (idx, value) in data.iter().enumerate() {
+        let Some(value) = value else {
+            continue;
+        };
 
-    for (idx, value) in data.iter().enumerate().skip(first_signal_idx + 1) {
-        let value = value.expect("aligned EMA input must be contiguous after the first value");
-        ema = alpha * value + (1.0 - alpha) * ema;
-        result[idx] = Some(ema);
+        if let Some(current_ema) = ema {
+            let next_ema = alpha * value + (1.0 - alpha) * current_ema;
+            ema = Some(next_ema);
+            result[idx] = Some(next_ema);
+            continue;
+        }
+
+        seed_sum += value;
+        seeded_count += 1;
+        if seeded_count == period {
+            let initial_ema = seed_sum / period as f64;
+            ema = Some(initial_ema);
+            result[idx] = Some(initial_ema);
+        }
     }
 
     result
-}
-
-fn mean_window(data: &[Option<f64>], start_idx: usize, period: usize) -> f64 {
-    data[start_idx..start_idx + period]
-        .iter()
-        .map(|value| value.expect("initial EMA window must be fully populated"))
-        .sum::<f64>()
-        / period as f64
 }
 
 #[cfg(test)]
@@ -58,9 +68,13 @@ mod tests {
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard EMA output against fixture data.
     #[test]
     fn test_ema() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
             let result = ema(&input, 20);
@@ -69,6 +83,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(result, 8),
                 round_vec(expected, 8),
@@ -76,5 +91,41 @@ mod tests {
                 symbol
             );
         }
+    }
+
+    /// Verifies that aligned EMA preserves offsets while matching dense EMA values.
+    #[test]
+    fn test_ema_aligned() {
+        // Given
+        let aligned = vec![None, None, Some(1.0), Some(2.0), Some(3.0), Some(4.0)];
+        let expected = vec![None, None, None, Some(1.5), Some(2.5), Some(3.5)];
+
+        // When
+        let result = ema_aligned(&aligned, 2);
+
+        // Then
+        assert_eq!(result, expected);
+    }
+
+    /// Verifies that aligned EMA skips interior gaps without panicking.
+    #[test]
+    fn test_ema_aligned_with_interior_gaps() {
+        // Given
+        let aligned = vec![
+            None,
+            None,
+            Some(1.0),
+            Some(2.0),
+            None,
+            Some(3.0),
+            Some(4.0),
+        ];
+        let expected = vec![None, None, None, Some(1.5), None, Some(2.5), Some(3.5)];
+
+        // When
+        let result = ema_aligned(&aligned, 2);
+
+        // Then
+        assert_eq!(result, expected);
     }
 }

--- a/core/src/indicators/ema.rs
+++ b/core/src/indicators/ema.rs
@@ -18,6 +18,40 @@ pub fn ema(data: &[f64], period: usize) -> Vec<Option<f64>> {
     result
 }
 
+pub(crate) fn ema_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    let mut result = vec![None; data.len()];
+    let Some(first_valid_idx) = data.iter().position(|value| value.is_some()) else {
+        return result;
+    };
+
+    let valid_len = data.len() - first_valid_idx;
+    if period == 0 || valid_len < period {
+        return result;
+    }
+
+    let first_signal_idx = first_valid_idx + period - 1;
+    let alpha = 2.0 / (period as f64 + 1.0);
+    let mut ema = mean_window(data, first_valid_idx, period);
+
+    result[first_signal_idx] = Some(ema);
+
+    for (idx, value) in data.iter().enumerate().skip(first_signal_idx + 1) {
+        let value = value.expect("aligned EMA input must be contiguous after the first value");
+        ema = alpha * value + (1.0 - alpha) * ema;
+        result[idx] = Some(ema);
+    }
+
+    result
+}
+
+fn mean_window(data: &[Option<f64>], start_idx: usize, period: usize) -> f64 {
+    data[start_idx..start_idx + period]
+        .iter()
+        .map(|value| value.expect("initial EMA window must be fully populated"))
+        .sum::<f64>()
+        / period as f64
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/indicators/ema.rs
+++ b/core/src/indicators/ema.rs
@@ -111,15 +111,7 @@ mod tests {
     #[test]
     fn test_ema_aligned_with_interior_gaps() {
         // Given
-        let aligned = vec![
-            None,
-            None,
-            Some(1.0),
-            Some(2.0),
-            None,
-            Some(3.0),
-            Some(4.0),
-        ];
+        let aligned = vec![None, None, Some(1.0), Some(2.0), None, Some(3.0), Some(4.0)];
         let expected = vec![None, None, None, Some(1.5), None, Some(2.5), Some(3.5)];
 
         // When

--- a/core/src/indicators/eom.rs
+++ b/core/src/indicators/eom.rs
@@ -1,4 +1,4 @@
-use crate::indicators::sma::sma;
+use crate::indicators::sma::{sma, sma_aligned};
 
 pub fn eom(
     highs: &[f64],
@@ -35,13 +35,7 @@ pub fn eom(
         eom_line[i + 1] = value;
     }
 
-    let eom_values: Vec<f64> = eom_line.iter().filter_map(|&x| x).collect();
-    let signal_sma = sma(&eom_values, signal_period);
-    let mut signal = vec![None; eom_line.len()];
-    let signal_offset = eom_line.len() - signal_sma.len();
-    for (i, &s) in signal_sma.iter().enumerate() {
-        signal[i + signal_offset] = s;
-    }
+    let signal = sma_aligned(&eom_line, signal_period);
 
     (eom_line, signal)
 }

--- a/core/src/indicators/eom.rs
+++ b/core/src/indicators/eom.rs
@@ -8,9 +8,34 @@ pub fn eom(
     signal_period: usize,
     scale: f64,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    let eom_line = eom_line(highs, lows, volumes, period, scale);
+    let signal = sma_aligned(&eom_line, signal_period);
+
+    (eom_line, signal)
+}
+
+pub fn eom_signal(
+    highs: &[f64],
+    lows: &[f64],
+    volumes: &[f64],
+    period: usize,
+    signal_period: usize,
+    scale: f64,
+) -> Vec<Option<f64>> {
+    let eom_line = eom_line(highs, lows, volumes, period, scale);
+    sma_aligned(&eom_line, signal_period)
+}
+
+pub fn eom_line(
+    highs: &[f64],
+    lows: &[f64],
+    volumes: &[f64],
+    period: usize,
+    scale: f64,
+) -> Vec<Option<f64>> {
     let len = highs.len();
     if len < 2 || len != lows.len() || len != volumes.len() {
-        return (vec![None; len], vec![None; len]);
+        return vec![None; len];
     }
 
     let mut eom_values = Vec::with_capacity(len - 1);
@@ -35,9 +60,7 @@ pub fn eom(
         eom_line[i + 1] = value;
     }
 
-    let signal = sma_aligned(&eom_line, signal_period);
-
-    (eom_line, signal)
+    eom_line
 }
 
 #[cfg(test)]
@@ -46,9 +69,13 @@ mod tests {
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard EOM outputs against fixture data.
     #[test]
     fn test_eom() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let highs = testutils::load_data(&format!("../data/{}.json", symbol), "h");
             let lows = testutils::load_data(&format!("../data/{}.json", symbol), "l");
@@ -65,6 +92,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(eom, 8),
                 round_vec(expected_eom, 8),

--- a/core/src/indicators/macd.rs
+++ b/core/src/indicators/macd.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::{ema, ema_aligned};
 
 pub fn macd(
     data: &[f64],
@@ -75,37 +75,7 @@ fn calc_macd_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<O
 }
 
 fn calc_macd_signal(macd_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    let mut signal_line = vec![None; macd_line.len()];
-    let Some(first_valid_idx) = macd_line.iter().position(|value| value.is_some()) else {
-        return signal_line;
-    };
-
-    let valid_len = macd_line.len() - first_valid_idx;
-    if signal_period == 0 || valid_len < signal_period {
-        return signal_line;
-    }
-
-    let first_signal_idx = first_valid_idx + signal_period - 1;
-    let mut signal = mean_macd_window(macd_line, first_valid_idx, signal_period);
-    let alpha = 2.0 / (signal_period as f64 + 1.0);
-
-    signal_line[first_signal_idx] = Some(signal);
-
-    for (idx, value) in macd_line.iter().enumerate().skip(first_signal_idx + 1) {
-        let macd = value.expect("macd_line becomes contiguous after the first valid value");
-        signal = alpha * macd + (1.0 - alpha) * signal;
-        signal_line[idx] = Some(signal);
-    }
-
-    signal_line
-}
-
-fn mean_macd_window(macd_line: &[Option<f64>], start_idx: usize, period: usize) -> f64 {
-    macd_line[start_idx..start_idx + period]
-        .iter()
-        .map(|value| value.expect("initial signal window must be fully populated"))
-        .sum::<f64>()
-        / period as f64
+    ema_aligned(macd_line, signal_period)
 }
 
 #[cfg(test)]

--- a/core/src/indicators/macd.rs
+++ b/core/src/indicators/macd.rs
@@ -75,22 +75,37 @@ fn calc_macd_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<O
 }
 
 fn calc_macd_signal(macd_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    let mut signal_line: Vec<Option<f64>> = vec![None; macd_line.len()];
-    let null_count = macd_line.iter().take_while(|&&x| x.is_none()).count();
-    let macd_values: Vec<f64> = macd_line
-        .iter()
-        .skip(null_count)
-        .filter_map(|&x| x)
-        .collect();
-    let ema_values = ema(&macd_values, signal_period);
+    let mut signal_line = vec![None; macd_line.len()];
+    let Some(first_valid_idx) = macd_line.iter().position(|value| value.is_some()) else {
+        return signal_line;
+    };
 
-    for i in 0..ema_values.len() {
-        if let Some(ema_value) = ema_values[i] {
-            signal_line[i + null_count] = Some(ema_value);
-        }
+    let valid_len = macd_line.len() - first_valid_idx;
+    if signal_period == 0 || valid_len < signal_period {
+        return signal_line;
+    }
+
+    let first_signal_idx = first_valid_idx + signal_period - 1;
+    let mut signal = mean_macd_window(macd_line, first_valid_idx, signal_period);
+    let alpha = 2.0 / (signal_period as f64 + 1.0);
+
+    signal_line[first_signal_idx] = Some(signal);
+
+    for (idx, value) in macd_line.iter().enumerate().skip(first_signal_idx + 1) {
+        let macd = value.expect("macd_line becomes contiguous after the first valid value");
+        signal = alpha * macd + (1.0 - alpha) * signal;
+        signal_line[idx] = Some(signal);
     }
 
     signal_line
+}
+
+fn mean_macd_window(macd_line: &[Option<f64>], start_idx: usize, period: usize) -> f64 {
+    macd_line[start_idx..start_idx + period]
+        .iter()
+        .map(|value| value.expect("initial signal window must be fully populated"))
+        .sum::<f64>()
+        / period as f64
 }
 
 #[cfg(test)]

--- a/core/src/indicators/macd.rs
+++ b/core/src/indicators/macd.rs
@@ -6,10 +6,8 @@ pub fn macd(
     slow_period: usize,
     signal_period: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>, Vec<Option<f64>>) {
-    let macd_line = calc_macd_line(data, fast_period, slow_period);
-    let signal_line = calc_macd_signal(&macd_line, signal_period);
-
-    // Calculate the histogram
+    let macd_line = macd_line(data, fast_period, slow_period);
+    let signal_line = ema_aligned(&macd_line, signal_period);
     let histogram = macd_line
         .iter()
         .zip(signal_line.iter())
@@ -22,28 +20,14 @@ pub fn macd(
     (macd_line, signal_line, histogram)
 }
 
-pub fn macd_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Option<f64>> {
-    calc_macd_line(data, fast_period, slow_period)
-}
-
-pub fn macd_signal(
-    data: &[f64],
-    fast_period: usize,
-    slow_period: usize,
-    signal_period: usize,
-) -> Vec<Option<f64>> {
-    let macd_line = calc_macd_line(data, fast_period, slow_period);
-    calc_macd_signal(&macd_line, signal_period)
-}
-
 pub fn macd_histogram(
     data: &[f64],
     fast_period: usize,
     slow_period: usize,
     signal_period: usize,
 ) -> Vec<Option<f64>> {
-    let macd_line = calc_macd_line(data, fast_period, slow_period);
-    let signal_line = calc_macd_signal(&macd_line, signal_period);
+    let macd_line = macd_line(data, fast_period, slow_period);
+    let signal_line = ema_aligned(&macd_line, signal_period);
 
     macd_line
         .iter()
@@ -55,7 +39,17 @@ pub fn macd_histogram(
         .collect()
 }
 
-fn calc_macd_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Option<f64>> {
+pub fn macd_signal(
+    data: &[f64],
+    fast_period: usize,
+    slow_period: usize,
+    signal_period: usize,
+) -> Vec<Option<f64>> {
+    let macd_line = macd_line(data, fast_period, slow_period);
+    ema_aligned(&macd_line, signal_period)
+}
+
+pub fn macd_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Option<f64>> {
     let mut macd_line = vec![None; data.len()];
 
     if data.len() < slow_period || fast_period >= slow_period {
@@ -74,19 +68,19 @@ fn calc_macd_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<O
     macd_line
 }
 
-fn calc_macd_signal(macd_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    ema_aligned(macd_line, signal_period)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard MACD outputs against fixture data.
     #[test]
     fn test_macd() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
             let (macd_line, signal_line, histogram) = macd(&input, 12, 26, 9);
@@ -104,6 +98,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(macd_line, 8),
                 round_vec(expected_macd, 8),

--- a/core/src/indicators/massi.rs
+++ b/core/src/indicators/massi.rs
@@ -7,12 +7,34 @@ pub fn massi(
     period_sum: usize,
     period_signal: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    let mass = massi_line(highs, lows, period_ema, period_sum);
+    let signal = ema_aligned(&mass, period_signal);
+
+    (mass, signal)
+}
+
+pub fn massi_signal(
+    highs: &[f64],
+    lows: &[f64],
+    period_ema: usize,
+    period_sum: usize,
+    period_signal: usize,
+) -> Vec<Option<f64>> {
+    let mass = massi_line(highs, lows, period_ema, period_sum);
+    ema_aligned(&mass, period_signal)
+}
+
+pub fn massi_line(
+    highs: &[f64],
+    lows: &[f64],
+    period_ema: usize,
+    period_sum: usize,
+) -> Vec<Option<f64>> {
     let len = highs.len();
     let mut mass = vec![None; len];
-    let mut signal = vec![None; len];
 
-    if len < 2 * (period_ema - 1) + (period_sum - 1) + 1 {
-        return (mass, signal);
+    if len != lows.len() || len < 2 * (period_ema - 1) + (period_sum - 1) + 1 {
+        return mass;
     }
 
     let high_low_diffs: Vec<f64> = highs.iter().zip(lows.iter()).map(|(h, l)| h - l).collect();
@@ -36,9 +58,7 @@ pub fn massi(
         }
     }
 
-    signal = ema_aligned(&mass, period_signal);
-
-    (mass, signal)
+    mass
 }
 
 #[cfg(test)]
@@ -47,9 +67,13 @@ mod tests {
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard MASSI outputs against fixture data.
     #[test]
     fn test_massi() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let highs = testutils::load_data(&format!("../data/{}.json", symbol), "h");
             let lows = testutils::load_data(&format!("../data/{}.json", symbol), "l");
@@ -65,6 +89,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(mass, 8),
                 round_vec(expected_mass, 8),

--- a/core/src/indicators/massi.rs
+++ b/core/src/indicators/massi.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::{ema, ema_aligned};
 
 pub fn massi(
     highs: &[f64],
@@ -17,13 +17,12 @@ pub fn massi(
 
     let high_low_diffs: Vec<f64> = highs.iter().zip(lows.iter()).map(|(h, l)| h - l).collect();
     let s_ema = ema(&high_low_diffs, period_ema);
-    let s_ema_filtered: Vec<f64> = s_ema.iter().filter_map(|&x| x).collect();
     let offset: usize = period_ema - 1;
-    let d_ema = ema(&s_ema_filtered, period_ema);
+    let d_ema = ema_aligned(&s_ema, period_ema);
 
-    let mut ema_ratio = Vec::with_capacity(d_ema.len());
-    for i in offset..d_ema.len() + offset {
-        if let (Some(s), Some(d)) = (s_ema[i], d_ema[i - offset]) {
+    let mut ema_ratio = Vec::with_capacity(len.saturating_sub(2 * offset));
+    for i in 0..len {
+        if let (Some(s), Some(d)) = (s_ema[i], d_ema[i]) {
             ema_ratio.push(s / d);
         }
     }
@@ -37,12 +36,7 @@ pub fn massi(
         }
     }
 
-    let mass_values: Vec<f64> = mass.iter().filter_map(|&x| x).collect();
-    let signal_ema = ema(&mass_values, period_signal);
-    let signal_offset = len - signal_ema.len();
-    for (i, &s) in signal_ema.iter().enumerate() {
-        signal[i + signal_offset] = s;
-    }
+    signal = ema_aligned(&mass, period_signal);
 
     (mass, signal)
 }

--- a/core/src/indicators/nvi.rs
+++ b/core/src/indicators/nvi.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::ema_aligned;
 
 pub fn nvi(
     closes: &[f64],
@@ -23,12 +23,7 @@ pub fn nvi(
         nvi_line[i] = Some(nvi_point);
     }
 
-    let nvi_values: Vec<f64> = nvi_line.iter().filter_map(|&x| x).collect();
-    let signal_ema = ema(&nvi_values, signal_period);
-    let signal_offset = len - signal_ema.len();
-    for (i, &s) in signal_ema.iter().enumerate() {
-        signal[i + signal_offset] = s;
-    }
+    signal = ema_aligned(&nvi_line, signal_period);
 
     (nvi_line, signal)
 }

--- a/core/src/indicators/nvi.rs
+++ b/core/src/indicators/nvi.rs
@@ -5,12 +5,23 @@ pub fn nvi(
     volumes: &[f64],
     signal_period: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    let nvi_line = nvi_line(closes, volumes);
+    let signal = ema_aligned(&nvi_line, signal_period);
+
+    (nvi_line, signal)
+}
+
+pub fn nvi_signal(closes: &[f64], volumes: &[f64], signal_period: usize) -> Vec<Option<f64>> {
+    let nvi_line = nvi_line(closes, volumes);
+    ema_aligned(&nvi_line, signal_period)
+}
+
+pub fn nvi_line(closes: &[f64], volumes: &[f64]) -> Vec<Option<f64>> {
     let len = closes.len();
     let mut nvi_line = vec![None; len];
-    let mut signal = vec![None; len];
 
-    if len < 2 {
-        return (nvi_line, signal);
+    if len < 2 || len != volumes.len() {
+        return nvi_line;
     }
 
     let mut nvi_point = 1000.0;
@@ -23,9 +34,7 @@ pub fn nvi(
         nvi_line[i] = Some(nvi_point);
     }
 
-    signal = ema_aligned(&nvi_line, signal_period);
-
-    (nvi_line, signal)
+    nvi_line
 }
 
 #[cfg(test)]
@@ -34,9 +43,13 @@ mod tests {
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard NVI outputs against fixture data.
     #[test]
     fn test_nvi() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let closes = testutils::load_data(&format!("../data/{}.json", symbol), "c");
             let volumes = testutils::load_data(&format!("../data/{}.json", symbol), "v");
@@ -52,6 +65,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(nvi, 8),
                 round_vec(expected_nvi, 8),

--- a/core/src/indicators/obv.rs
+++ b/core/src/indicators/obv.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::ema_aligned;
 
 pub fn obv(
     data: &[f64],
@@ -44,23 +44,7 @@ fn calc_obv_line(data: &[f64], volumes: &[f64]) -> Vec<Option<f64>> {
 }
 
 fn obv_signal_by_obvline(obv_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    let mut obv_signal = vec![None; obv_line.len()];
-
-    let null_count = obv_line.iter().take_while(|&&x| x.is_none()).count();
-    let obv_values = obv_line
-        .iter()
-        .skip(null_count)
-        .filter_map(|&v| v)
-        .collect::<Vec<f64>>();
-    let ema_obv = ema(&obv_values, signal_period);
-
-    for i in 0..ema_obv.len() {
-        if let Some(ema_value) = ema_obv[i] {
-            obv_signal[i + null_count] = Some(ema_value);
-        }
-    }
-
-    obv_signal
+    ema_aligned(obv_line, signal_period)
 }
 
 #[cfg(test)]

--- a/core/src/indicators/obv.rs
+++ b/core/src/indicators/obv.rs
@@ -5,13 +5,18 @@ pub fn obv(
     volumes: &[f64],
     signal_period: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
-    let obv_line = calc_obv_line(data, volumes);
-    let obv_signal = obv_signal_by_obvline(&obv_line, signal_period);
+    let obv_line = obv_line(data, volumes);
+    let obv_signal = ema_aligned(&obv_line, signal_period);
 
     (obv_line, obv_signal)
 }
 
-fn calc_obv_line(data: &[f64], volumes: &[f64]) -> Vec<Option<f64>> {
+pub fn obv_signal(data: &[f64], volumes: &[f64], signal_period: usize) -> Vec<Option<f64>> {
+    let obv_line = obv_line(data, volumes);
+    ema_aligned(&obv_line, signal_period)
+}
+
+pub fn obv_line(data: &[f64], volumes: &[f64]) -> Vec<Option<f64>> {
     let mut obv = vec![None; data.len()];
 
     let len = data.len();
@@ -43,19 +48,19 @@ fn calc_obv_line(data: &[f64], volumes: &[f64]) -> Vec<Option<f64>> {
     obv
 }
 
-fn obv_signal_by_obvline(obv_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    ema_aligned(obv_line, signal_period)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard OBV outputs against fixture data.
     #[test]
     fn test_obv() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let close = testutils::load_data(&format!("../data/{}.json", symbol), "c");
             let volume = testutils::load_data(&format!("../data/{}.json", symbol), "v");
@@ -70,6 +75,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(line, 4),
                 round_vec(expected_line, 4),

--- a/core/src/indicators/ppo.rs
+++ b/core/src/indicators/ppo.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::{ema, ema_aligned};
 
 pub fn ppo(
     data: &[f64],
@@ -42,19 +42,7 @@ fn calc_ppo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Op
 }
 
 fn calc_ppo_signal(ppo_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    let mut signal_line: Vec<Option<f64>> = vec![None; ppo_line.len()];
-    let ppo_values: Vec<f64> = ppo_line.iter().filter_map(|&x| x).collect();
-    let offset = ppo_line.len() - ppo_values.len();
-
-    let ema_values = ema(&ppo_values, signal_period);
-
-    for i in 0..ema_values.len() {
-        if let Some(ema_value) = ema_values[i] {
-            signal_line[i + offset] = Some(ema_value);
-        }
-    }
-
-    signal_line
+    ema_aligned(ppo_line, signal_period)
 }
 
 #[cfg(test)]

--- a/core/src/indicators/ppo.rs
+++ b/core/src/indicators/ppo.rs
@@ -6,8 +6,8 @@ pub fn ppo(
     slow_period: usize,
     signal_period: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>, Vec<Option<f64>>) {
-    let ppo_line = calc_ppo_line(data, fast_period, slow_period);
-    let signal_line = calc_ppo_signal(&ppo_line, signal_period);
+    let ppo_line = ppo_line(data, fast_period, slow_period);
+    let signal_line = ema_aligned(&ppo_line, signal_period);
     let histogram = ppo_line
         .iter()
         .zip(signal_line.iter())
@@ -20,7 +20,35 @@ pub fn ppo(
     (ppo_line, signal_line, histogram)
 }
 
-fn calc_ppo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Option<f64>> {
+pub fn ppo_histogram(
+    data: &[f64],
+    fast_period: usize,
+    slow_period: usize,
+    signal_period: usize,
+) -> Vec<Option<f64>> {
+    let ppo_line = ppo_line(data, fast_period, slow_period);
+    let signal_line = ema_aligned(&ppo_line, signal_period);
+    ppo_line
+        .iter()
+        .zip(signal_line.iter())
+        .map(|(&ppo, &signal)| match (ppo, signal) {
+            (Some(p), Some(s)) => Some(p - s),
+            _ => None,
+        })
+        .collect()
+}
+
+pub fn ppo_signal(
+    data: &[f64],
+    fast_period: usize,
+    slow_period: usize,
+    signal_period: usize,
+) -> Vec<Option<f64>> {
+    let ppo_line = ppo_line(data, fast_period, slow_period);
+    ema_aligned(&ppo_line, signal_period)
+}
+
+pub fn ppo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Option<f64>> {
     let mut ppo_line = vec![None; data.len()];
 
     if data.len() < slow_period || fast_period >= slow_period {
@@ -41,18 +69,14 @@ fn calc_ppo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Op
     ppo_line
 }
 
-fn calc_ppo_signal(ppo_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    ema_aligned(ppo_line, signal_period)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testutils;
     use crate::utils::round_vec;
 
-    #[test]
     /// Verifies the standard PPO output against fixture data.
+    #[test]
     fn test_ppo() {
         // Given
         let test_cases = vec!["005930", "TSLA"];

--- a/core/src/indicators/ppo.rs
+++ b/core/src/indicators/ppo.rs
@@ -52,8 +52,12 @@ mod tests {
     use crate::utils::round_vec;
 
     #[test]
+    /// Verifies the standard PPO output against fixture data.
     fn test_ppo() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
             let (ppo_line, signal_line, histogram) = ppo(&input, 12, 26, 9);
@@ -71,6 +75,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(ppo_line, 8),
                 round_vec(expected_ppo, 8),

--- a/core/src/indicators/pvi.rs
+++ b/core/src/indicators/pvi.rs
@@ -5,12 +5,23 @@ pub fn pvi(
     volumes: &[f64],
     signal_period: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    let pvi_line = pvi_line(closes, volumes);
+    let signal = ema_aligned(&pvi_line, signal_period);
+
+    (pvi_line, signal)
+}
+
+pub fn pvi_signal(closes: &[f64], volumes: &[f64], signal_period: usize) -> Vec<Option<f64>> {
+    let pvi_line = pvi_line(closes, volumes);
+    ema_aligned(&pvi_line, signal_period)
+}
+
+pub fn pvi_line(closes: &[f64], volumes: &[f64]) -> Vec<Option<f64>> {
     let len = closes.len();
     let mut pvi_line = vec![None; len];
-    let mut signal = vec![None; len];
 
-    if len < 2 {
-        return (pvi_line, signal);
+    if len < 2 || len != volumes.len() {
+        return pvi_line;
     }
 
     let mut pvi_point = 1000.0;
@@ -23,9 +34,7 @@ pub fn pvi(
         pvi_line[i] = Some(pvi_point);
     }
 
-    signal = ema_aligned(&pvi_line, signal_period);
-
-    (pvi_line, signal)
+    pvi_line
 }
 
 #[cfg(test)]
@@ -34,9 +43,13 @@ mod tests {
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard PVI outputs against fixture data.
     #[test]
     fn test_pvi() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let closes = testutils::load_data(&format!("../data/{}.json", symbol), "c");
             let volumes = testutils::load_data(&format!("../data/{}.json", symbol), "v");
@@ -52,6 +65,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(pvi, 8),
                 round_vec(expected_pvi, 8),

--- a/core/src/indicators/pvi.rs
+++ b/core/src/indicators/pvi.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::ema_aligned;
 
 pub fn pvi(
     closes: &[f64],
@@ -23,12 +23,7 @@ pub fn pvi(
         pvi_line[i] = Some(pvi_point);
     }
 
-    let pvi_values: Vec<f64> = pvi_line.iter().filter_map(|&x| x).collect();
-    let signal_ema = ema(&pvi_values, signal_period);
-    let signal_offset = len - signal_ema.len();
-    for (i, &s) in signal_ema.iter().enumerate() {
-        signal[i + signal_offset] = s;
-    }
+    signal = ema_aligned(&pvi_line, signal_period);
 
     (pvi_line, signal)
 }

--- a/core/src/indicators/pvo.rs
+++ b/core/src/indicators/pvo.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::{ema, ema_aligned};
 
 pub fn pvo(
     data: &[f64],
@@ -44,19 +44,7 @@ fn calc_pvo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Op
 }
 
 fn calc_pvo_signal(pvo_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    let mut signal_line: Vec<Option<f64>> = vec![None; pvo_line.len()];
-    let pvo_values: Vec<f64> = pvo_line.iter().filter_map(|&x| x).collect();
-    let offset = pvo_line.len() - pvo_values.len();
-
-    let ema_values = ema(&pvo_values, signal_period);
-
-    for i in 0..ema_values.len() {
-        if let Some(ema_value) = ema_values[i] {
-            signal_line[i + offset] = Some(ema_value);
-        }
-    }
-
-    signal_line
+    ema_aligned(pvo_line, signal_period)
 }
 #[cfg(test)]
 mod tests {

--- a/core/src/indicators/pvo.rs
+++ b/core/src/indicators/pvo.rs
@@ -6,10 +6,8 @@ pub fn pvo(
     slow_period: usize,
     signal_period: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>, Vec<Option<f64>>) {
-    let pvo_line = calc_pvo_line(data, fast_period, slow_period);
-    let signal_line = calc_pvo_signal(&pvo_line, signal_period);
-
-    // Calculate the histogram
+    let pvo_line = pvo_line(data, fast_period, slow_period);
+    let signal_line = ema_aligned(&pvo_line, signal_period);
     let histogram = pvo_line
         .iter()
         .zip(signal_line.iter())
@@ -22,7 +20,35 @@ pub fn pvo(
     (pvo_line, signal_line, histogram)
 }
 
-fn calc_pvo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Option<f64>> {
+pub fn pvo_histogram(
+    data: &[f64],
+    fast_period: usize,
+    slow_period: usize,
+    signal_period: usize,
+) -> Vec<Option<f64>> {
+    let pvo_line = pvo_line(data, fast_period, slow_period);
+    let signal_line = ema_aligned(&pvo_line, signal_period);
+    pvo_line
+        .iter()
+        .zip(signal_line.iter())
+        .map(|(&pvo, &signal)| match (pvo, signal) {
+            (Some(p), Some(s)) => Some(p - s),
+            _ => None,
+        })
+        .collect()
+}
+
+pub fn pvo_signal(
+    data: &[f64],
+    fast_period: usize,
+    slow_period: usize,
+    signal_period: usize,
+) -> Vec<Option<f64>> {
+    let pvo_line = pvo_line(data, fast_period, slow_period);
+    ema_aligned(&pvo_line, signal_period)
+}
+
+pub fn pvo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Option<f64>> {
     let mut pvo_line = vec![None; data.len()];
 
     if data.len() < slow_period || fast_period >= slow_period {
@@ -43,17 +69,14 @@ fn calc_pvo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Op
     pvo_line
 }
 
-fn calc_pvo_signal(pvo_line: &[Option<f64>], signal_period: usize) -> Vec<Option<f64>> {
-    ema_aligned(pvo_line, signal_period)
-}
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::testutils;
     use crate::utils::round_vec;
 
-    #[test]
     /// Verifies the standard PVO output against fixture data.
+    #[test]
     fn test_pvo() {
         // Given
         let test_cases = vec!["005930", "TSLA"];

--- a/core/src/indicators/pvo.rs
+++ b/core/src/indicators/pvo.rs
@@ -53,8 +53,12 @@ mod tests {
     use crate::utils::round_vec;
 
     #[test]
+    /// Verifies the standard PVO output against fixture data.
     fn test_pvo() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let input = testutils::load_data(&format!("../data/{}.json", symbol), "v");
             let (pvo_line, signal_line, histogram) = pvo(&input, 12, 26, 9);
@@ -72,6 +76,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(pvo_line, 8),
                 round_vec(expected_pvo, 8),

--- a/core/src/indicators/sma.rs
+++ b/core/src/indicators/sma.rs
@@ -1,3 +1,7 @@
+/// Computes a simple moving average over a dense `f64` series.
+///
+/// The returned vector keeps the same length as the input and emits `None`
+/// until the first full `period` window has been observed.
 pub fn sma(data: &[f64], period: usize) -> Vec<Option<f64>> {
     let mut sma = vec![None; data.len()];
     let mut sum = 0.0;
@@ -19,6 +23,12 @@ pub fn sma(data: &[f64], period: usize) -> Vec<Option<f64>> {
     sma
 }
 
+/// Computes an SMA over an aligned optional series.
+///
+/// The input is expected to contain an optional prefix of `None` values followed
+/// by a contiguous run of `Some(f64)` values. The returned vector preserves the
+/// original alignment while avoiding the extra compaction/remapping pass that
+/// would otherwise be needed before applying `sma`.
 pub(crate) fn sma_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let mut result = vec![None; data.len()];
     let Some(first_valid_idx) = data.iter().position(|value| value.is_some()) else {
@@ -56,9 +66,13 @@ mod tests {
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard SMA output against fixture data.
     #[test]
     fn test_sma() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
             let result = sma(&input, 20);
@@ -67,6 +81,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(result, 8),
                 expected,
@@ -74,5 +89,19 @@ mod tests {
                 symbol
             );
         }
+    }
+
+    /// Verifies that aligned SMA preserves offsets while matching dense SMA values.
+    #[test]
+    fn test_sma_aligned() {
+        // Given
+        let aligned = vec![None, None, Some(1.0), Some(2.0), Some(3.0), Some(4.0)];
+        let expected = vec![None, None, None, Some(1.5), Some(2.5), Some(3.5)];
+
+        // When
+        let result = sma_aligned(&aligned, 2);
+
+        // Then
+        assert_eq!(result, expected);
     }
 }

--- a/core/src/indicators/sma.rs
+++ b/core/src/indicators/sma.rs
@@ -19,6 +19,37 @@ pub fn sma(data: &[f64], period: usize) -> Vec<Option<f64>> {
     sma
 }
 
+pub(crate) fn sma_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    let mut result = vec![None; data.len()];
+    let Some(first_valid_idx) = data.iter().position(|value| value.is_some()) else {
+        return result;
+    };
+
+    let valid_len = data.len() - first_valid_idx;
+    if period == 0 || valid_len < period {
+        return result;
+    }
+
+    let mut sum = 0.0;
+    for value in data.iter().skip(first_valid_idx).take(period) {
+        sum += value.expect("initial SMA window must be fully populated");
+    }
+
+    let first_signal_idx = first_valid_idx + period - 1;
+    result[first_signal_idx] = Some(sum / period as f64);
+
+    for idx in (first_signal_idx + 1)..data.len() {
+        let entering =
+            data[idx].expect("aligned SMA input must be contiguous after the first value");
+        let leaving =
+            data[idx - period].expect("aligned SMA input must be contiguous after the first value");
+        sum += entering - leaving;
+        result[idx] = Some(sum / period as f64);
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/indicators/sonar.rs
+++ b/core/src/indicators/sonar.rs
@@ -6,11 +6,27 @@ pub fn sonar(
     step: usize,
     signal_period: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    let sonar_line = sonar_line(data, period, step);
+    let signal_line = ema_aligned(&sonar_line, signal_period);
+
+    (sonar_line, signal_line)
+}
+
+pub fn sonar_signal(
+    data: &[f64],
+    period: usize,
+    step: usize,
+    signal_period: usize,
+) -> Vec<Option<f64>> {
+    let sonar_line = sonar_line(data, period, step);
+    ema_aligned(&sonar_line, signal_period)
+}
+
+pub fn sonar_line(data: &[f64], period: usize, step: usize) -> Vec<Option<f64>> {
     let mut sonar_line = vec![None; data.len()];
-    let mut signal_line = vec![None; data.len()];
 
     if data.len() < period + step {
-        return (sonar_line, signal_line);
+        return sonar_line;
     }
 
     let ema_values = ema(data, period);
@@ -21,9 +37,7 @@ pub fn sonar(
         }
     }
 
-    signal_line = ema_aligned(&sonar_line, signal_period);
-
-    (sonar_line, signal_line)
+    sonar_line
 }
 
 #[cfg(test)]
@@ -32,9 +46,13 @@ mod tests {
     use crate::testutils;
     use crate::utils::round_vec;
 
+    /// Verifies the standard SONAR outputs against fixture data.
     #[test]
     fn test_sonar() {
+        // Given
         let test_cases = vec!["005930", "TSLA"];
+
+        // When
         for symbol in test_cases {
             let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
             let (sonar_line, signal_line) = sonar(&input, 9, 6, 5);
@@ -48,6 +66,7 @@ mod tests {
                 symbol
             ));
 
+            // Then
             assert_eq!(
                 round_vec(sonar_line, 8),
                 round_vec(expected_sonar, 8),

--- a/core/src/indicators/sonar.rs
+++ b/core/src/indicators/sonar.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::{ema, ema_aligned};
 
 pub fn sonar(
     data: &[f64],
@@ -21,13 +21,7 @@ pub fn sonar(
         }
     }
 
-    let sonar_values: Vec<f64> = sonar_line.iter().filter_map(|&x| x).collect();
-    let signal_ema = ema(&sonar_values, signal_period);
-    let offset = data.len() - sonar_values.len();
-
-    for (i, &value) in signal_ema.iter().enumerate() {
-        signal_line[i + offset] = value;
-    }
+    signal_line = ema_aligned(&sonar_line, signal_period);
 
     (sonar_line, signal_line)
 }


### PR DESCRIPTION
## 요약

여러 지표의 signal 계산 경로에서 임시 압축 벡터를 만들지 않고, 기존 `Vec<Option<f64>>` 정렬을 유지한 채 EMA/SMA를 직접 계산하도록 최적화했습니다.

## 변경 사항

- `core/src/indicators/ema.rs`에 `ema_aligned` 추가
- `core/src/indicators/sma.rs`에 `sma_aligned` 추가
- 다음 signal 계산 경로를 aligned helper 기반으로 전환
  - `macd_signal`
  - `ppo_signal`
  - `pvo_signal`
  - `obv_signal`
  - `sonar` signal
  - `nvi` signal
  - `pvi` signal
  - `massi` 내부 EMA 경로
  - `eom` signal SMA 경로
- 공개 API와 반환 형태는 유지

## 변경 이유

기존 구현은 공통적으로 다음 비용을 반복해서 지불하고 있었습니다.

- `filter_map(...).collect()`로 유효 구간만 새 벡터로 압축
- 압축된 벡터에 `EMA` 또는 `SMA` 적용
- 계산 결과를 원래 offset에 맞춰 다시 복사

하지만 이 지표들은 대부분 첫 유효 값 이후 구간이 이미 정렬된 형태이므로, 임시 벡터를 만들지 않고도 같은 결과를 계산할 수 있습니다.

## 벤치마크

`origin/main` (`cb2e4ff`) 대비, `techr-core` release 벤치 1,000,000 rows, 5회 실행 중앙값 기준입니다.

| 항목 | origin/main | this branch | 변화 |
| --- | ---: | ---: | ---: |
| `macd_signal` | `12.8ms` | `9.6ms` | `-25.0%` |
| `macd_hist` | `13.0ms` | `9.9ms` | `-23.8%` |
| `ppo_signal` | `14.0ms` | `9.7ms` | `-30.7%` |
| `ppo_hist` | `14.2ms` | `9.7ms` | `-31.7%` |
| `pvo_signal` | `13.4ms` | `9.9ms` | `-26.1%` |
| `pvo_hist` | `12.4ms` | `9.8ms` | `-21.0%` |
| `obv_signal` | `6.4ms` | `3.7ms` | `-42.2%` |
| `sonar_signal` | `9.5ms` | `6.7ms` | `-29.5%` |
| `nvi_signal` | `7.9ms` | `5.0ms` | `-36.7%` |
| `pvi_signal` | `6.8ms` | `4.2ms` | `-38.2%` |
| `massi_signal` | `17.0ms` | `11.9ms` | `-30.0%` |
| `eom_signal` | `10.0ms` | `6.2ms` | `-38.0%` |

## 벤치마크 스크립트

```rust
use std::time::Instant;

const RUNS: usize = 5;

type Case<'a> = (&'a str, Box<dyn Fn() + 'a>);

fn make_series(len: usize) -> (Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>) {
    let mut highs = Vec::with_capacity(len);
    let mut lows = Vec::with_capacity(len);
    let mut closes = Vec::with_capacity(len);
    let mut volumes = Vec::with_capacity(len);
    for i in 0..len {
        let angle = i as f64 * 0.0007;
        let base = 100.0 + angle.sin() * 15.0 + angle.cos() * 9.0 + (i % 251) as f64 * 0.02;
        highs.push(base + 2.5 + ((i % 11) as f64 * 0.01));
        lows.push(base - 2.5 - ((i % 13) as f64 * 0.01));
        closes.push(base + ((i % 7) as f64 - 3.0) * 0.05);
        volumes.push(10_000.0 + ((i % 113) as f64 * 17.0) + angle.sin().abs() * 500.0);
    }
    (highs, lows, closes, volumes)
}

fn median(values: &mut [f64]) -> f64 {
    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
    values[values.len() / 2]
}

fn measure(case: &dyn Fn()) -> f64 {
    let start = Instant::now();
    case();
    start.elapsed().as_secs_f64() * 1000.0
}

fn main() {
    let (highs, lows, closes, volumes) = make_series(1_000_000);
    let cases: Vec<Case> = vec![
        ("macd_signal", Box::new(|| { let _ = techr::macd(&closes, 12, 26, 9).1; })),
        ("macd_hist", Box::new(|| { let _ = techr::macd(&closes, 12, 26, 9).2; })),
        ("ppo_signal", Box::new(|| { let _ = techr::ppo(&closes, 12, 26, 9).1; })),
        ("ppo_hist", Box::new(|| { let _ = techr::ppo(&closes, 12, 26, 9).2; })),
        ("pvo_signal", Box::new(|| { let _ = techr::pvo(&volumes, 12, 26, 9).1; })),
        ("pvo_hist", Box::new(|| { let _ = techr::pvo(&volumes, 12, 26, 9).2; })),
        ("obv_signal", Box::new(|| { let _ = techr::obv(&closes, &volumes, 9).1; })),
        ("sonar_signal", Box::new(|| { let _ = techr::sonar(&closes, 9, 6, 5).1; })),
        ("nvi_signal", Box::new(|| { let _ = techr::nvi(&closes, &volumes, 255).1; })),
        ("pvi_signal", Box::new(|| { let _ = techr::pvi(&closes, &volumes, 255).1; })),
        ("massi_signal", Box::new(|| { let _ = techr::massi(&highs, &lows, 9, 25, 9).1; })),
        ("eom_signal", Box::new(|| { let _ = techr::eom(&highs, &lows, &volumes, 14, 3, 10_000.0).1; })),
    ];

    for (_, case) in &cases {
        case();
    }

    for (name, case) in cases {
        let mut samples = (0..RUNS).map(|_| measure(&*case)).collect::<Vec<_>>();
        let median = median(&mut samples);
        println!("{}_samples_ms={:?}", name, samples.iter().map(|v| format!("{v:.1}")).collect::<Vec<_>>());
        println!("{}_median_ms={median:.1}", name);
    }
}
```

## 검증

- `cargo test --manifest-path core/Cargo.toml`
- `cargo check --manifest-path polars/Cargo.toml`
- `cd polars && uv run pytest`
