### PR TITLE
♻️ polars 릴리스 자동화 단순화

### DIFF
--- a/.github/workflows/polars-auto-release.yml
+++ b/.github/workflows/polars-auto-release.yml
@@ -1,0 +1,72 @@
+name: Polars Auto Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "polars/Cargo.toml"
+  workflow_dispatch:
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      release_created: ${{ steps.version.outputs.release_created }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Determine release version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_tag="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          cargo = tomllib.loads(Path("polars/Cargo.toml").read_text())
+          print(f"polars-v{cargo['package']['version']}")
+          PY
+          )"
+
+          latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq '
+            map(select(.draft == false and .prerelease == false and (.tag_name | startswith("polars-v"))))
+            | .[0].tag_name // ""
+          ')"
+
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+
+          if [ "$release_tag" = "$latest_tag" ]; then
+            echo "release_created=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_created=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create published GitHub release
+        if: steps.version.outputs.release_created == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.release_tag }}
+          name: ${{ steps.version.outputs.release_tag }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+
+  publish-pypi:
+    if: needs.create-release.outputs.release_created == 'true'
+    needs: create-release
+    permissions:
+      contents: read
+      id-token: write
+    # Releases created with the default GitHub token do not fan out into new
+    # workflow runs, so reuse the publish workflow directly here.
+    uses: ./.github/workflows/polars-release.yml
+    secrets: inherit

--- a/.github/workflows/polars-release.yml
+++ b/.github/workflows/polars-release.yml
@@ -1,10 +1,7 @@
 name: Polars Release
 
 on:
-  push:
-    tags:
-      - "polars-v*"
-  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
@@ -190,28 +187,10 @@ jobs:
           name: wheels-sdist
           path: polars/dist/*
 
-  publish-testpypi:
-    if: github.event_name == 'workflow_dispatch'
-    needs: [build-linux, build-macos, build-windows, build-sdist]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist
-          skip-existing: true
-
   publish-pypi:
-    if: github.event_name == 'push'
     needs: [build-linux, build-macos, build-windows, build-sdist]
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: read
       id-token: write

--- a/polars/README.md
+++ b/polars/README.md
@@ -73,8 +73,10 @@ uv run python scripts/check_artifacts.py dist
 ## Release
 
 1. Update the version in `Cargo.toml`.
-2. Optionally build release artifacts locally for a final preflight check.
-3. Optionally run the `Polars Release` workflow manually to publish the current ref to TestPyPI.
-4. Create and push a `polars-vX.Y.Z` tag to publish to PyPI.
+2. Merge the version bump to `main`.
+3. `Polars Auto Release` creates and publishes the matching `polars-vX.Y.Z` GitHub Release.
+4. That release publishes the built artifacts to PyPI automatically.
 
-Before the first release, configure Trusted Publishers for both PyPI and TestPyPI on `alphaprime-dev/techr`.
+Any production GitHub Release tag must match the version in `Cargo.toml`.
+
+Before the first release, configure a Trusted Publisher for PyPI on `alphaprime-dev/techr`.


### PR DESCRIPTION
## 요약
- `polars` 패키지의 릴리스 생성 판단을 `Polars Auto Release` 워크플로로 분리해 `main`의 `Cargo.toml` 버전 변경이 GitHub Release와 PyPI 배포로 자동으로 이어지도록 정리했습니다.
- 기존 `Polars Release` 워크플로는 reusable publish workflow로 단순화하고, TestPyPI 및 수동 태그 기반 분기를 제거했습니다.
- `polars/README.md`의 릴리스 절차를 새 자동화 흐름과 PyPI Trusted Publisher 기준에 맞게 업데이트했습니다.

## 워크플로우 다이어그램
```mermaid
flowchart TD
    versionBump["Update version in Cargo.toml"] --> mergeMain["Merge to main"]
    mergeMain --> autoRelease["Run Polars Auto Release"]
    autoRelease --> createRelease["Create GitHub Release polars-vX.Y.Z"]
    createRelease --> publishWorkflow["Call Polars Release workflow"]
    publishWorkflow --> buildArtifacts["Build wheels and sdist"]
    buildArtifacts --> publishPyPI["Publish artifacts to PyPI"]
```

## 테스트 계획
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/polars-auto-release.yml"); YAML.load_file(".github/workflows/polars-release.yml")'`
- [ ] GitHub Actions에서 `Polars Auto Release`와 PyPI publish 실제 실행 확인

Made with [Cursor](https://cursor.com)