### PR TITLE
♻️ core 지표 nullable 입력 계약 도입

### DIFF
--- a/.github/workflows/polars-ci.yml
+++ b/.github/workflows/polars-ci.yml
@@ -5,7 +5,6 @@ on:
     types: [review_requested, ready_for_review, synchronize]
     paths:
       - ".github/workflows/polars-*.yml"
-      - "!.github/workflows/polars-ci.yml"
       - "Cargo.toml"
       - "Makefile"
       - "polars/**"
@@ -18,7 +17,26 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      validate: ${{ steps.filter.outputs.validate }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            validate:
+              - "Cargo.toml"
+              - "Makefile"
+              - "polars/**"
+
   validate:
+    needs: preflight
+    if: ${{ needs.preflight.outputs.validate == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/polars-ci.yml
+++ b/.github/workflows/polars-ci.yml
@@ -2,12 +2,11 @@ name: Polars CI
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [review_requested, ready_for_review, synchronize]
     paths:
       - ".github/workflows/polars-*.yml"
       - "Cargo.toml"
       - "Makefile"
-      - "core/**"
       - "polars/**"
 
 concurrency:

--- a/.github/workflows/polars-ci.yml
+++ b/.github/workflows/polars-ci.yml
@@ -5,6 +5,7 @@ on:
     types: [review_requested, ready_for_review, synchronize]
     paths:
       - ".github/workflows/polars-*.yml"
+      - "!.github/workflows/polars-ci.yml"
       - "Cargo.toml"
       - "Makefile"
       - "polars/**"

--- a/.github/workflows/polars-ci.yml
+++ b/.github/workflows/polars-ci.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       validate: ${{ steps.filter.outputs.validate }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
         id: filter
         with:
           filters: |
@@ -36,42 +36,63 @@ jobs:
 
   validate:
     needs: preflight
-    if: ${{ needs.preflight.outputs.validate == 'true' }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - name: Fail if preflight did not succeed
+        if: ${{ needs.preflight.result != 'success' }}
+        run: |
+          echo "preflight job did not succeed: ${{ needs.preflight.result }}"
+          exit 1
+
+      - name: Skip validation for non-polars changes
+        if: ${{ needs.preflight.result == 'success' && needs.preflight.outputs.validate != 'true' }}
+        run: echo "Skipping Polars CI validate job because this PR does not touch Cargo.toml, Makefile, or polars/**."
+
+      - if: ${{ needs.preflight.outputs.validate == 'true' }}
+        uses: actions/checkout@v6
+      - if: ${{ needs.preflight.outputs.validate == 'true' }}
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-      - uses: astral-sh/setup-uv@v8.0.0
-      - uses: dtolnay/rust-toolchain@stable
+      - if: ${{ needs.preflight.outputs.validate == 'true' }}
+        uses: astral-sh/setup-uv@v8.0.0
+      - if: ${{ needs.preflight.outputs.validate == 'true' }}
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Sync polars dependencies
+        if: ${{ needs.preflight.outputs.validate == 'true' }}
         working-directory: polars
         run: uv sync --group dev --no-install-project
 
       - name: Test techr-core
+        if: ${{ needs.preflight.outputs.validate == 'true' }}
         run: cargo test -p techr-core
 
       - name: Build local extension for tests
+        if: ${{ needs.preflight.outputs.validate == 'true' }}
         working-directory: polars
         run: uv run maturin develop --uv
 
       - name: Test polars package
+        if: ${{ needs.preflight.outputs.validate == 'true' }}
         working-directory: polars
         run: uv run pytest
 
       - name: Build wheel and sdist
+        if: ${{ needs.preflight.outputs.validate == 'true' }}
         working-directory: polars
         run: uv run maturin build --release --sdist --out dist
 
       - name: Check artifact contents
+        if: ${{ needs.preflight.outputs.validate == 'true' }}
         run: python polars/scripts/check_artifacts.py polars/dist
 
       - name: Smoke test built wheel
+        if: ${{ needs.preflight.outputs.validate == 'true' }}
         run: |
           wheel="$(python - <<'PY'
           from pathlib import Path

--- a/core/src/indicators/bband.rs
+++ b/core/src/indicators/bband.rs
@@ -1,9 +1,8 @@
 use crate::indicators::sma::sma;
-
-use crate::utils::round_scalar;
+use crate::utils::{rolling_mean_stddev_strict, round_scalar};
 
 pub fn bband(
-    data: &[f64],
+    data: &[Option<f64>],
     period: usize,
     sigma: Option<f64>,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>, Vec<Option<f64>>) {
@@ -12,55 +11,42 @@ pub fn bband(
     (upper_band, center, lower_band)
 }
 
-pub fn bband_middle(data: &[f64], period: usize) -> Vec<Option<f64>> {
+pub fn bband_middle(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     sma(data, period)
 }
 
-pub fn bband_upper(data: &[f64], period: usize, sigma: Option<f64>) -> Vec<Option<f64>> {
+pub fn bband_upper(data: &[Option<f64>], period: usize, sigma: Option<f64>) -> Vec<Option<f64>> {
     let (upper_band, _) = bband_bands(data, period, sigma);
     upper_band
 }
 
-pub fn bband_lower(data: &[f64], period: usize, sigma: Option<f64>) -> Vec<Option<f64>> {
+pub fn bband_lower(data: &[Option<f64>], period: usize, sigma: Option<f64>) -> Vec<Option<f64>> {
     let (_, lower_band) = bband_bands(data, period, sigma);
     lower_band
 }
 
 fn bband_bands(
-    data: &[f64],
+    data: &[Option<f64>],
     period: usize,
     sigma: Option<f64>,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
-    let mut upper_band = vec![None; data.len()];
-    let mut lower_band = vec![None; data.len()];
-    let mut sum = 0.0;
-    let mut sum_sq = 0.0;
     let sigma = sigma.unwrap_or(2.0);
+    let (means, stddevs) = rolling_mean_stddev_strict(data, period);
 
-    if data.len() < period {
-        return (upper_band, lower_band);
-    }
-
-    for i in 0..data.len() {
-        sum += data[i];
-        sum_sq += data[i] * data[i];
-
-        if i >= period {
-            sum -= data[i - period];
-            sum_sq -= data[i - period] * data[i - period];
-        }
-
-        if i >= period - 1 {
-            let mean = sum / period as f64;
-            let variance = (sum_sq / period as f64) - (mean * mean);
-            let stddev = variance.sqrt();
-            let deviation = sigma * stddev;
-            upper_band[i] = Some(round_scalar(mean + deviation, 8));
-            lower_band[i] = Some(round_scalar(mean - deviation, 8));
-        }
-    }
-
-    (upper_band, lower_band)
+    means
+        .into_iter()
+        .zip(stddevs)
+        .map(|(mean, stddev)| match (mean, stddev) {
+            (Some(mean), Some(stddev)) => {
+                let deviation = sigma * stddev;
+                (
+                    Some(round_scalar(mean + deviation, 8)),
+                    Some(round_scalar(mean - deviation, 8)),
+                )
+            }
+            _ => (None, None),
+        })
+        .unzip()
 }
 
 #[cfg(test)]
@@ -73,7 +59,10 @@ mod tests {
     fn test_bband() {
         let test_cases = vec!["005930", "TSLA"];
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
+            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>();
             let (upper, middle, lower) = bband(&input, 20, None);
 
             let expected_upper = testutils::load_expected::<Option<f64>>(&format!(
@@ -108,5 +97,27 @@ mod tests {
                 symbol
             );
         }
+    }
+
+    #[test]
+    fn test_bband_with_interior_gap_invalidates_full_window() {
+        let input = vec![Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)];
+
+        let (upper, middle, lower) = bband(&input, 2, Some(2.0));
+
+        assert_eq!(middle, vec![None, Some(1.5), None, None, Some(4.5)]);
+        assert_eq!(upper, vec![None, Some(2.5), None, None, Some(5.5)]);
+        assert_eq!(lower, vec![None, Some(0.5), None, None, Some(3.5)]);
+    }
+
+    #[test]
+    fn test_bband_full_window_invalidation() {
+        let input = vec![None, Some(2.0), None, Some(4.0)];
+
+        let (upper, middle, lower) = bband(&input, 2, None);
+
+        assert_eq!(upper, vec![None, None, None, None]);
+        assert_eq!(middle, vec![None, None, None, None]);
+        assert_eq!(lower, vec![None, None, None, None]);
     }
 }

--- a/core/src/indicators/bband.rs
+++ b/core/src/indicators/bband.rs
@@ -59,10 +59,7 @@ mod tests {
     fn test_bband() {
         let test_cases = vec!["005930", "TSLA"];
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
-                .into_iter()
-                .map(Some)
-                .collect::<Vec<_>>();
+            let input = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "c");
             let (upper, middle, lower) = bband(&input, 20, None);
 
             let expected_upper = testutils::load_expected::<Option<f64>>(&format!(

--- a/core/src/indicators/cv.rs
+++ b/core/src/indicators/cv.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::ema_dense;
 
 pub fn cv(highs: &[f64], lows: &[f64], period: usize) -> Vec<Option<f64>> {
     let mut cv = vec![None; highs.len()];
@@ -9,7 +9,7 @@ pub fn cv(highs: &[f64], lows: &[f64], period: usize) -> Vec<Option<f64>> {
     }
 
     let high_low_diffs: Vec<f64> = highs.iter().zip(lows.iter()).map(|(h, l)| h - l).collect();
-    let ema_high_low_diffs = ema(&high_low_diffs, period);
+    let ema_high_low_diffs = ema_dense(&high_low_diffs, period);
 
     for i in period * 2 - 1..len {
         if let (Some(current_ema), Some(previous_ema)) =

--- a/core/src/indicators/disparity.rs
+++ b/core/src/indicators/disparity.rs
@@ -35,10 +35,7 @@ mod tests {
     fn test_disparity() {
         let test_cases = vec!["005930", "TSLA"];
         for symbol in test_cases {
-            let close = testutils::load_data(&format!("../data/{}.json", symbol), "c")
-                .into_iter()
-                .map(Some)
-                .collect::<Vec<_>>();
+            let close = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "c");
             let result = disparity(&close, 20);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/disparity_{}.json",

--- a/core/src/indicators/disparity.rs
+++ b/core/src/indicators/disparity.rs
@@ -1,19 +1,23 @@
 use crate::indicators::sma::sma;
 
-pub fn disparity(data: &[f64], period: usize) -> Vec<Option<f64>> {
+pub fn disparity(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let len = data.len();
     let mut result = vec![None; len];
 
-    if len < period {
+    if len < period || period == 0 {
         return result;
     }
 
     let sma = sma(data, period);
 
     for i in period - 1..len {
+        let Some(value) = data[i] else {
+            continue;
+        };
+
         if let Some(sma_value) = sma[i] {
             if sma_value != 0.0 {
-                result[i] = Some((data[i] / sma_value) * 100.0);
+                result[i] = Some((value / sma_value) * 100.0);
             }
         }
     }
@@ -31,7 +35,10 @@ mod tests {
     fn test_disparity() {
         let test_cases = vec!["005930", "TSLA"];
         for symbol in test_cases {
-            let close = testutils::load_data(&format!("../data/{}.json", symbol), "c");
+            let close = testutils::load_data(&format!("../data/{}.json", symbol), "c")
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>();
             let result = disparity(&close, 20);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/disparity_{}.json",
@@ -45,5 +52,30 @@ mod tests {
                 symbol
             );
         }
+    }
+
+    #[test]
+    fn test_disparity_with_interior_gap_invalidates_window() {
+        let input = vec![Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)];
+        let expected = vec![
+            None,
+            Some(133.33333333333331),
+            None,
+            None,
+            Some(111.11111111111111),
+        ];
+
+        let result = disparity(&input, 2);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_disparity_full_window_invalidation() {
+        let input = vec![None, Some(2.0), None, Some(4.0)];
+
+        let result = disparity(&input, 2);
+
+        assert_eq!(result, vec![None, None, None, None]);
     }
 }

--- a/core/src/indicators/efi.rs
+++ b/core/src/indicators/efi.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::ema_dense;
 
 pub fn efi(closes: &[f64], volumes: &[f64], period: usize) -> Vec<Option<f64>> {
     let len = closes.len();
@@ -22,7 +22,7 @@ pub fn efi(closes: &[f64], volumes: &[f64], period: usize) -> Vec<Option<f64>> {
                 *efi_val = Some(force_val);
             });
     } else {
-        let ema_result = ema(&force, period);
+        let ema_result = ema_dense(&force, period);
         efi.iter_mut()
             .skip(1)
             .zip(ema_result.into_iter())

--- a/core/src/indicators/ema.rs
+++ b/core/src/indicators/ema.rs
@@ -52,9 +52,7 @@ pub fn ema(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     ema_impl(data, period)
 }
 
-pub(crate) fn ema_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    ema_impl(data, period)
-}
+pub(crate) use ema as ema_aligned;
 
 #[cfg(test)]
 mod tests {
@@ -70,10 +68,7 @@ mod tests {
 
         // When
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
-                .into_iter()
-                .map(Some)
-                .collect::<Vec<_>>();
+            let input = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "c");
             let result = ema(&input, 20);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/ema_{}.json",

--- a/core/src/indicators/ema.rs
+++ b/core/src/indicators/ema.rs
@@ -1,35 +1,7 @@
-/// Computes an exponential moving average over a dense `f64` series.
-///
-/// The returned vector keeps the same length as the input and emits `None`
-/// until the first full `period` window has been observed.
-pub fn ema(data: &[f64], period: usize) -> Vec<Option<f64>> {
+fn ema_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let mut result = vec![None; data.len()];
 
-    if data.len() < period {
-        return result;
-    }
-
-    let alpha = 2.0 / (period as f64 + 1.0);
-    let mut ema = data[..period].iter().sum::<f64>() / period as f64;
-
-    result[period - 1] = Some(ema);
-
-    for i in period..data.len() {
-        ema = alpha * data[i] + (1.0 - alpha) * ema;
-        result[i] = Some(ema);
-    }
-
-    result
-}
-
-/// Computes an EMA over an optional series while preserving original alignment.
-///
-/// The EMA state advances only on `Some(f64)` values, so interior `None` holes
-/// are skipped safely. This lets callers avoid compacting a sparse aligned
-/// series into a temporary dense vector before applying `ema`.
-pub(crate) fn ema_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    let mut result = vec![None; data.len()];
-    if period == 0 {
+    if data.len() < period || period == 0 {
         return result;
     }
 
@@ -38,8 +10,8 @@ pub(crate) fn ema_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64
     let mut seed_sum = 0.0;
     let mut ema = None;
 
-    for (idx, value) in data.iter().enumerate() {
-        let Some(value) = value else {
+    for (idx, item) in data.iter().enumerate() {
+        let Some(value) = *item else {
             continue;
         };
 
@@ -62,6 +34,23 @@ pub(crate) fn ema_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64
     result
 }
 
+pub(crate) fn ema_dense(data: &[f64], period: usize) -> Vec<Option<f64>> {
+    let nullable = data.iter().copied().map(Some).collect::<Vec<_>>();
+    ema_impl(&nullable, period)
+}
+
+/// Computes an exponential moving average over an aligned nullable series.
+///
+/// The returned vector keeps the same length as the input and emits `None`
+/// until the first full valid `period` observations have been observed.
+pub fn ema(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    ema_impl(data, period)
+}
+
+pub(crate) fn ema_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    ema_impl(data, period)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,7 +65,10 @@ mod tests {
 
         // When
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
+            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>();
             let result = ema(&input, 20);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/ema_{}.json",
@@ -93,31 +85,33 @@ mod tests {
         }
     }
 
-    /// Verifies that aligned EMA preserves offsets while matching dense EMA values.
     #[test]
-    fn test_ema_aligned() {
-        // Given
+    fn test_ema_with_prefix_gap() {
         let aligned = vec![None, None, Some(1.0), Some(2.0), Some(3.0), Some(4.0)];
         let expected = vec![None, None, None, Some(1.5), Some(2.5), Some(3.5)];
 
-        // When
-        let result = ema_aligned(&aligned, 2);
+        let result = ema(&aligned, 2);
 
-        // Then
         assert_eq!(result, expected);
     }
 
-    /// Verifies that aligned EMA skips interior gaps without panicking.
     #[test]
-    fn test_ema_aligned_with_interior_gaps() {
-        // Given
+    fn test_ema_with_interior_gaps_resumes_from_prior_state() {
         let aligned = vec![None, None, Some(1.0), Some(2.0), None, Some(3.0), Some(4.0)];
         let expected = vec![None, None, None, Some(1.5), None, Some(2.5), Some(3.5)];
 
-        // When
-        let result = ema_aligned(&aligned, 2);
+        let result = ema(&aligned, 2);
 
-        // Then
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_ema_full_window_invalidation_before_seed() {
+        let aligned = vec![Some(1.0), None, Some(3.0), None];
+        let expected = vec![None, None, None, None];
+
+        let result = ema(&aligned, 3);
+
         assert_eq!(result, expected);
     }
 }

--- a/core/src/indicators/ema.rs
+++ b/core/src/indicators/ema.rs
@@ -12,6 +12,10 @@ fn ema_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
 
     for (idx, item) in data.iter().enumerate() {
         let Some(value) = *item else {
+            if ema.is_none() {
+                seeded_count = 0;
+                seed_sum = 0.0;
+            }
             continue;
         };
 
@@ -42,7 +46,8 @@ pub(crate) fn ema_dense(data: &[f64], period: usize) -> Vec<Option<f64>> {
 /// Computes an exponential moving average over an aligned nullable series.
 ///
 /// The returned vector keeps the same length as the input and emits `None`
-/// until the first full valid `period` observations have been observed.
+/// until the first contiguous run of `period` valid observations has been
+/// observed. Once seeded, gaps emit `None` without resetting the EMA state.
 pub fn ema(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     ema_impl(data, period)
 }
@@ -106,9 +111,17 @@ mod tests {
     }
 
     #[test]
-    fn test_ema_full_window_invalidation_before_seed() {
-        let aligned = vec![Some(1.0), None, Some(3.0), None];
-        let expected = vec![None, None, None, None];
+    fn test_ema_requires_contiguous_values_before_seed() {
+        let aligned = vec![
+            Some(1.0),
+            Some(2.0),
+            None,
+            Some(3.0),
+            Some(4.0),
+            Some(5.0),
+            Some(6.0),
+        ];
+        let expected = vec![None, None, None, None, None, Some(4.0), Some(5.0)];
 
         let result = ema(&aligned, 3);
 

--- a/core/src/indicators/ema.rs
+++ b/core/src/indicators/ema.rs
@@ -1,4 +1,14 @@
-fn ema_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+pub(crate) fn ema_dense(data: &[f64], period: usize) -> Vec<Option<f64>> {
+    let nullable = data.iter().copied().map(Some).collect::<Vec<_>>();
+    ema(&nullable, period)
+}
+
+/// Computes an exponential moving average over an aligned nullable series.
+///
+/// The returned vector keeps the same length as the input and emits `None`
+/// until the first contiguous run of `period` valid observations has been
+/// observed. Once seeded, gaps emit `None` without resetting the EMA state.
+pub fn ema(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let mut result = vec![None; data.len()];
 
     if data.len() < period || period == 0 {
@@ -36,20 +46,6 @@ fn ema_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     }
 
     result
-}
-
-pub(crate) fn ema_dense(data: &[f64], period: usize) -> Vec<Option<f64>> {
-    let nullable = data.iter().copied().map(Some).collect::<Vec<_>>();
-    ema_impl(&nullable, period)
-}
-
-/// Computes an exponential moving average over an aligned nullable series.
-///
-/// The returned vector keeps the same length as the input and emits `None`
-/// until the first contiguous run of `period` valid observations has been
-/// observed. Once seeded, gaps emit `None` without resetting the EMA state.
-pub fn ema(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    ema_impl(data, period)
 }
 
 pub(crate) use ema as ema_aligned;

--- a/core/src/indicators/env.rs
+++ b/core/src/indicators/env.rs
@@ -1,7 +1,7 @@
 use crate::indicators::sma::sma;
 
 pub fn env(
-    data: &[f64],
+    data: &[Option<f64>],
     period: usize,
     shift_percentage: f64,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>, Vec<Option<f64>>) {
@@ -33,7 +33,10 @@ mod tests {
     fn test_env() {
         let test_cases = vec!["005930", "TSLA"];
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
+            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>();
             let result = env(&input, 20, 10.0);
 
             let (env_upper, sma_values, env_lower) = result;
@@ -66,5 +69,33 @@ mod tests {
                 symbol
             );
         }
+    }
+
+    #[test]
+    fn test_env_with_interior_gap_invalidates_window() {
+        let input = vec![Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)];
+
+        let (upper, middle, lower) = env(&input, 2, 10.0);
+
+        assert_eq!(middle, vec![None, Some(1.5), None, None, Some(4.5)]);
+        assert_eq!(
+            round_vec(upper, 8),
+            vec![None, Some(1.65), None, None, Some(4.95)]
+        );
+        assert_eq!(
+            round_vec(lower, 8),
+            vec![None, Some(1.35), None, None, Some(4.05)]
+        );
+    }
+
+    #[test]
+    fn test_env_full_window_invalidation() {
+        let input = vec![None, Some(2.0), None, Some(4.0)];
+
+        let (upper, middle, lower) = env(&input, 2, 10.0);
+
+        assert_eq!(upper, vec![None, None, None, None]);
+        assert_eq!(middle, vec![None, None, None, None]);
+        assert_eq!(lower, vec![None, None, None, None]);
     }
 }

--- a/core/src/indicators/env.rs
+++ b/core/src/indicators/env.rs
@@ -33,10 +33,7 @@ mod tests {
     fn test_env() {
         let test_cases = vec!["005930", "TSLA"];
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
-                .into_iter()
-                .map(Some)
-                .collect::<Vec<_>>();
+            let input = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "c");
             let result = env(&input, 20, 10.0);
 
             let (env_upper, sma_values, env_lower) = result;

--- a/core/src/indicators/eom.rs
+++ b/core/src/indicators/eom.rs
@@ -1,4 +1,4 @@
-use crate::indicators::sma::{sma, sma_aligned};
+use crate::indicators::sma::{sma_aligned, sma_dense};
 
 pub fn eom(
     highs: &[f64],
@@ -55,7 +55,7 @@ pub fn eom_line(
     }
 
     let mut eom_line = vec![None; len];
-    let eom_sma = sma(&eom_values, period);
+    let eom_sma = sma_dense(&eom_values, period);
     for (i, &value) in eom_sma.iter().enumerate() {
         eom_line[i + 1] = value;
     }

--- a/core/src/indicators/erbear.rs
+++ b/core/src/indicators/erbear.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::ema_dense;
 
 pub fn erbear(lows: &[f64], closes: &[f64], period: usize) -> Vec<Option<f64>> {
     let mut erbear = vec![None; lows.len()];
@@ -7,7 +7,7 @@ pub fn erbear(lows: &[f64], closes: &[f64], period: usize) -> Vec<Option<f64>> {
         return erbear;
     }
 
-    let ema_values = ema(closes, period);
+    let ema_values = ema_dense(closes, period);
 
     for i in (period - 1)..lows.len() {
         if let Some(ema_value) = ema_values[i] {

--- a/core/src/indicators/erbull.rs
+++ b/core/src/indicators/erbull.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::ema;
+use crate::indicators::ema::ema_dense;
 
 pub fn erbull(highs: &[f64], closes: &[f64], period: usize) -> Vec<Option<f64>> {
     let mut erbull = vec![None; highs.len()];
@@ -7,7 +7,7 @@ pub fn erbull(highs: &[f64], closes: &[f64], period: usize) -> Vec<Option<f64>> 
         return erbull;
     }
 
-    let ema_values = ema(closes, period);
+    let ema_values = ema_dense(closes, period);
 
     for i in (period - 1)..highs.len() {
         if let Some(ema_value) = ema_values[i] {

--- a/core/src/indicators/macd.rs
+++ b/core/src/indicators/macd.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::{ema, ema_aligned};
+use crate::indicators::ema::{ema_aligned, ema_dense};
 
 pub fn macd(
     data: &[f64],
@@ -56,8 +56,8 @@ pub fn macd_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Op
         return macd_line;
     }
 
-    let fast_ema = ema(data, fast_period);
-    let slow_ema = ema(data, slow_period);
+    let fast_ema = ema_dense(data, fast_period);
+    let slow_ema = ema_dense(data, slow_period);
 
     for i in (slow_period - 1)..data.len() {
         if let (Some(fast), Some(slow)) = (fast_ema[i], slow_ema[i]) {

--- a/core/src/indicators/massi.rs
+++ b/core/src/indicators/massi.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::{ema, ema_aligned};
+use crate::indicators::ema::{ema_aligned, ema_dense};
 
 pub fn massi(
     highs: &[f64],
@@ -38,7 +38,7 @@ pub fn massi_line(
     }
 
     let high_low_diffs: Vec<f64> = highs.iter().zip(lows.iter()).map(|(h, l)| h - l).collect();
-    let s_ema = ema(&high_low_diffs, period_ema);
+    let s_ema = ema_dense(&high_low_diffs, period_ema);
     let offset: usize = period_ema - 1;
     let d_ema = ema_aligned(&s_ema, period_ema);
 

--- a/core/src/indicators/ppo.rs
+++ b/core/src/indicators/ppo.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::{ema, ema_aligned};
+use crate::indicators::ema::{ema_aligned, ema_dense};
 
 pub fn ppo(
     data: &[f64],
@@ -55,8 +55,8 @@ pub fn ppo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Opt
         return ppo_line;
     }
 
-    let fast_ema = ema(data, fast_period);
-    let slow_ema = ema(data, slow_period);
+    let fast_ema = ema_dense(data, fast_period);
+    let slow_ema = ema_dense(data, slow_period);
 
     for i in (slow_period - 1)..data.len() {
         if let (Some(fast), Some(slow)) = (fast_ema[i], slow_ema[i]) {

--- a/core/src/indicators/pvo.rs
+++ b/core/src/indicators/pvo.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::{ema, ema_aligned};
+use crate::indicators::ema::{ema_aligned, ema_dense};
 
 pub fn pvo(
     data: &[f64],
@@ -55,8 +55,8 @@ pub fn pvo_line(data: &[f64], fast_period: usize, slow_period: usize) -> Vec<Opt
         return pvo_line;
     }
 
-    let fast_ema = ema(data, fast_period);
-    let slow_ema = ema(data, slow_period);
+    let fast_ema = ema_dense(data, fast_period);
+    let slow_ema = ema_dense(data, slow_period);
 
     for i in (slow_period - 1)..data.len() {
         if let (Some(fast), Some(slow)) = (fast_ema[i], slow_ema[i]) {

--- a/core/src/indicators/sma.rs
+++ b/core/src/indicators/sma.rs
@@ -17,9 +17,7 @@ pub fn sma(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     sma_impl(data, period)
 }
 
-pub(crate) fn sma_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    sma_impl(data, period)
-}
+pub(crate) use sma as sma_aligned;
 
 #[cfg(test)]
 mod tests {
@@ -35,10 +33,7 @@ mod tests {
 
         // When
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
-                .into_iter()
-                .map(Some)
-                .collect::<Vec<_>>();
+            let input = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "c");
             let result = sma(&input, 20);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/sma_{}.json",

--- a/core/src/indicators/sma.rs
+++ b/core/src/indicators/sma.rs
@@ -1,63 +1,24 @@
-/// Computes a simple moving average over a dense `f64` series.
+use crate::utils::rolling_mean_strict;
+
+fn sma_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    rolling_mean_strict(data, period)
+}
+
+pub(crate) fn sma_dense(data: &[f64], period: usize) -> Vec<Option<f64>> {
+    let nullable = data.iter().copied().map(Some).collect::<Vec<_>>();
+    sma_impl(&nullable, period)
+}
+
+/// Computes a simple moving average over an aligned nullable series.
 ///
 /// The returned vector keeps the same length as the input and emits `None`
 /// until the first full `period` window has been observed.
-pub fn sma(data: &[f64], period: usize) -> Vec<Option<f64>> {
-    let mut sma = vec![None; data.len()];
-    let mut sum = 0.0;
-
-    if data.len() < period {
-        return sma;
-    }
-
-    for i in 0..data.len() {
-        sum += data[i];
-        if i >= period {
-            sum -= data[i - period];
-        }
-        if i >= period - 1 {
-            sma[i] = Some(sum / period as f64);
-        }
-    }
-
-    sma
+pub fn sma(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    sma_impl(data, period)
 }
 
-/// Computes an SMA over an aligned optional series.
-///
-/// The input is expected to contain an optional prefix of `None` values followed
-/// by a contiguous run of `Some(f64)` values. The returned vector preserves the
-/// original alignment while avoiding the extra compaction/remapping pass that
-/// would otherwise be needed before applying `sma`.
 pub(crate) fn sma_aligned(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    let mut result = vec![None; data.len()];
-    let Some(first_valid_idx) = data.iter().position(|value| value.is_some()) else {
-        return result;
-    };
-
-    let valid_len = data.len() - first_valid_idx;
-    if period == 0 || valid_len < period {
-        return result;
-    }
-
-    let mut sum = 0.0;
-    for value in data.iter().skip(first_valid_idx).take(period) {
-        sum += value.expect("initial SMA window must be fully populated");
-    }
-
-    let first_signal_idx = first_valid_idx + period - 1;
-    result[first_signal_idx] = Some(sum / period as f64);
-
-    for idx in (first_signal_idx + 1)..data.len() {
-        let entering =
-            data[idx].expect("aligned SMA input must be contiguous after the first value");
-        let leaving =
-            data[idx - period].expect("aligned SMA input must be contiguous after the first value");
-        sum += entering - leaving;
-        result[idx] = Some(sum / period as f64);
-    }
-
-    result
+    sma_impl(data, period)
 }
 
 #[cfg(test)]
@@ -74,7 +35,10 @@ mod tests {
 
         // When
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
+            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>();
             let result = sma(&input, 20);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/sma_{}.json",
@@ -91,17 +55,33 @@ mod tests {
         }
     }
 
-    /// Verifies that aligned SMA preserves offsets while matching dense SMA values.
     #[test]
-    fn test_sma_aligned() {
-        // Given
+    fn test_sma_with_prefix_gap() {
         let aligned = vec![None, None, Some(1.0), Some(2.0), Some(3.0), Some(4.0)];
         let expected = vec![None, None, None, Some(1.5), Some(2.5), Some(3.5)];
 
-        // When
-        let result = sma_aligned(&aligned, 2);
+        let result = sma(&aligned, 2);
 
-        // Then
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sma_with_interior_gap_invalidates_window() {
+        let aligned = vec![Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)];
+        let expected = vec![None, Some(1.5), None, None, Some(4.5)];
+
+        let result = sma(&aligned, 2);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sma_full_window_invalidation() {
+        let aligned = vec![Some(1.0), None, None, Some(4.0)];
+        let expected = vec![None, None, None, None];
+
+        let result = sma(&aligned, 2);
+
         assert_eq!(result, expected);
     }
 }

--- a/core/src/indicators/sma.rs
+++ b/core/src/indicators/sma.rs
@@ -1,12 +1,8 @@
 use crate::utils::rolling_mean_strict;
 
-fn sma_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    rolling_mean_strict(data, period)
-}
-
 pub(crate) fn sma_dense(data: &[f64], period: usize) -> Vec<Option<f64>> {
     let nullable = data.iter().copied().map(Some).collect::<Vec<_>>();
-    sma_impl(&nullable, period)
+    rolling_mean_strict(&nullable, period)
 }
 
 /// Computes a simple moving average over an aligned nullable series.
@@ -14,7 +10,7 @@ pub(crate) fn sma_dense(data: &[f64], period: usize) -> Vec<Option<f64>> {
 /// The returned vector keeps the same length as the input and emits `None`
 /// until the first full `period` window has been observed.
 pub fn sma(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    sma_impl(data, period)
+    rolling_mean_strict(data, period)
 }
 
 pub(crate) use sma as sma_aligned;

--- a/core/src/indicators/sonar.rs
+++ b/core/src/indicators/sonar.rs
@@ -1,4 +1,4 @@
-use crate::indicators::ema::{ema, ema_aligned};
+use crate::indicators::ema::{ema_aligned, ema_dense};
 
 pub fn sonar(
     data: &[f64],
@@ -29,7 +29,7 @@ pub fn sonar_line(data: &[f64], period: usize, step: usize) -> Vec<Option<f64>> 
         return sonar_line;
     }
 
-    let ema_values = ema(data, period);
+    let ema_values = ema_dense(data, period);
 
     for i in (period + step - 1)..data.len() {
         if let (Some(current_ema), Some(previous_ema)) = (ema_values[i], ema_values[i - step]) {

--- a/core/src/indicators/wma.rs
+++ b/core/src/indicators/wma.rs
@@ -1,11 +1,7 @@
 use crate::utils::rolling_weighted_mean_strict;
 
-fn wma_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    rolling_weighted_mean_strict(data, period)
-}
-
 pub fn wma(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    wma_impl(data, period)
+    rolling_weighted_mean_strict(data, period)
 }
 
 #[cfg(test)]

--- a/core/src/indicators/wma.rs
+++ b/core/src/indicators/wma.rs
@@ -1,27 +1,11 @@
-pub fn wma(data: &[f64], period: usize) -> Vec<Option<f64>> {
-    let mut result = vec![None; data.len()];
+use crate::utils::rolling_weighted_mean_strict;
 
-    if data.len() < period {
-        return result;
-    }
+fn wma_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    rolling_weighted_mean_strict(data, period)
+}
 
-    let weight_sum = (period * (period + 1)) / 2;
-    let mut weighted_sum = 0.0;
-
-    // Initialize the first period
-    for i in 0..period {
-        weighted_sum += data[i] * (i + 1) as f64;
-    }
-
-    for i in period - 1..data.len() {
-        result[i] = Some(weighted_sum / weight_sum as f64);
-        if i + 1 < data.len() {
-            weighted_sum = weighted_sum + data[i + 1] * period as f64
-                - data[i + 1 - period..=i].iter().sum::<f64>();
-        }
-    }
-
-    result
+pub fn wma(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    wma_impl(data, period)
 }
 
 #[cfg(test)]
@@ -34,7 +18,10 @@ mod tests {
     fn test_wma() {
         let test_cases = vec!["005930", "TSLA"];
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c");
+            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
+                .into_iter()
+                .map(Some)
+                .collect::<Vec<_>>();
             let result = wma(&input, 20);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/wma_{}.json",
@@ -48,5 +35,35 @@ mod tests {
                 symbol
             );
         }
+    }
+
+    #[test]
+    fn test_wma_with_prefix_gap() {
+        let aligned = vec![None, Some(1.0), Some(2.0), Some(3.0)];
+        let expected = vec![None, None, Some(5.0 / 3.0), Some(8.0 / 3.0)];
+
+        let result = wma(&aligned, 2);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_wma_with_interior_gap_invalidates_window() {
+        let aligned = vec![Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)];
+        let expected = vec![None, Some(5.0 / 3.0), None, None, Some(14.0 / 3.0)];
+
+        let result = wma(&aligned, 2);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_wma_full_window_invalidation() {
+        let aligned = vec![Some(1.0), None, None, Some(4.0)];
+        let expected = vec![None, None, None, None];
+
+        let result = wma(&aligned, 2);
+
+        assert_eq!(result, expected);
     }
 }

--- a/core/src/indicators/wma.rs
+++ b/core/src/indicators/wma.rs
@@ -18,10 +18,7 @@ mod tests {
     fn test_wma() {
         let test_cases = vec!["005930", "TSLA"];
         for symbol in test_cases {
-            let input = testutils::load_data(&format!("../data/{}.json", symbol), "c")
-                .into_iter()
-                .map(Some)
-                .collect::<Vec<_>>();
+            let input = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "c");
             let result = wma(&input, 20);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/wma_{}.json",

--- a/core/src/testutils.rs
+++ b/core/src/testutils.rs
@@ -18,6 +18,11 @@ pub fn load_data(path: &str, field: &str) -> Vec<f64> {
 }
 
 #[cfg(test)]
+pub fn load_data_nullable(path: &str, field: &str) -> Vec<Option<f64>> {
+    load_data(path, field).into_iter().map(Some).collect()
+}
+
+#[cfg(test)]
 pub fn load_expected<T: serde::de::DeserializeOwned>(path: &str) -> Vec<T> {
     use std::fs;
 

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -121,8 +121,7 @@ pub fn rolling_midpoint(highs: &[f64], lows: &[f64], period: usize) -> Vec<Optio
         .collect()
 }
 
-/// Computes a rolling mean that only emits a value when the full window contains `Some` values.
-pub fn rolling_mean_strict(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+fn rolling_mean_strict_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let len = data.len();
     let mut means = vec![None; len];
 
@@ -152,6 +151,99 @@ pub fn rolling_mean_strict(data: &[Option<f64>], period: usize) -> Vec<Option<f6
     }
 
     means
+}
+
+/// Computes a rolling mean that only emits a value when the full window contains valid values.
+pub fn rolling_mean_strict(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    rolling_mean_strict_impl(data, period)
+}
+
+/// Computes a rolling weighted mean that only emits a value when the full window is valid.
+fn rolling_weighted_mean_strict_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    let len = data.len();
+    let mut result = vec![None; len];
+
+    if len < period || period == 0 {
+        return result;
+    }
+
+    let weight_sum = (period * (period + 1)) as f64 / 2.0;
+
+    for end in (period - 1)..len {
+        let start = end + 1 - period;
+        let mut weighted_sum = 0.0;
+        let mut valid = true;
+
+        for (offset, item) in data[start..=end].iter().enumerate() {
+            let Some(value) = *item else {
+                valid = false;
+                break;
+            };
+            weighted_sum += value * (offset + 1) as f64;
+        }
+
+        if valid {
+            result[end] = Some(weighted_sum / weight_sum);
+        }
+    }
+
+    result
+}
+
+/// Computes a rolling weighted mean that only emits a value when the full window is valid.
+pub fn rolling_weighted_mean_strict(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+    rolling_weighted_mean_strict_impl(data, period)
+}
+
+/// Computes rolling mean and standard deviation for fully valid windows only.
+fn rolling_mean_stddev_strict_impl(
+    data: &[Option<f64>],
+    period: usize,
+) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    let len = data.len();
+    let mut means = vec![None; len];
+    let mut stddevs = vec![None; len];
+
+    if len < period || period == 0 {
+        return (means, stddevs);
+    }
+
+    let mut sum = 0.0;
+    let mut sum_sq = 0.0;
+    let mut valid_count = 0usize;
+
+    for i in 0..len {
+        if let Some(value) = data[i] {
+            sum += value;
+            sum_sq += value * value;
+            valid_count += 1;
+        }
+
+        if i >= period {
+            if let Some(value) = data[i - period] {
+                sum -= value;
+                sum_sq -= value * value;
+                valid_count -= 1;
+            }
+        }
+
+        if i >= period - 1 && valid_count == period {
+            let mean = sum / period as f64;
+            let variance = (sum_sq / period as f64) - (mean * mean);
+            means[i] = Some(mean);
+            stddevs[i] = Some(variance.max(0.0).sqrt());
+        }
+    }
+
+    (means, stddevs)
+}
+
+/// Computes rolling mean and standard deviation for fully valid windows only.
+pub fn rolling_mean_stddev_strict(
+    data: &[Option<f64>],
+    period: usize,
+) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    rolling_mean_stddev_strict_impl(data, period)
 }
 
 fn push_max_index(deque: &mut VecDeque<usize>, data: &[f64], idx: usize) {
@@ -391,6 +483,25 @@ mod tests {
         let means = rolling_mean_strict(&data, 2);
 
         assert_eq!(means, vec![None, Some(2.0), None, None, Some(6.0)]);
+    }
+
+    #[test]
+    fn test_rolling_weighted_mean_strict() {
+        let data = vec![None, Some(1.0), Some(2.0), None, Some(4.0)];
+
+        let means = rolling_weighted_mean_strict(&data, 2);
+
+        assert_eq!(means, vec![None, None, Some(5.0 / 3.0), None, None]);
+    }
+
+    #[test]
+    fn test_rolling_mean_stddev_strict() {
+        let data = vec![Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)];
+
+        let (means, stddevs) = rolling_mean_stddev_strict(&data, 2);
+
+        assert_eq!(means, vec![None, Some(1.5), None, None, Some(4.5)]);
+        assert_eq!(stddevs, vec![None, Some(0.5), None, None, Some(0.5)]);
     }
 
     #[test]

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -121,7 +121,8 @@ pub fn rolling_midpoint(highs: &[f64], lows: &[f64], period: usize) -> Vec<Optio
         .collect()
 }
 
-fn rolling_mean_strict_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+/// Computes a rolling mean that only emits a value when the full window contains valid values.
+pub fn rolling_mean_strict(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let len = data.len();
     let mut means = vec![None; len];
 
@@ -153,13 +154,8 @@ fn rolling_mean_strict_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f
     means
 }
 
-/// Computes a rolling mean that only emits a value when the full window contains valid values.
-pub fn rolling_mean_strict(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    rolling_mean_strict_impl(data, period)
-}
-
 /// Computes a rolling weighted mean that only emits a value when the full window is valid.
-fn rolling_weighted_mean_strict_impl(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+pub fn rolling_weighted_mean_strict(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let len = data.len();
     let mut result = vec![None; len];
 
@@ -206,13 +202,8 @@ fn rolling_weighted_mean_strict_impl(data: &[Option<f64>], period: usize) -> Vec
     result
 }
 
-/// Computes a rolling weighted mean that only emits a value when the full window is valid.
-pub fn rolling_weighted_mean_strict(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
-    rolling_weighted_mean_strict_impl(data, period)
-}
-
 /// Computes rolling mean and standard deviation for fully valid windows only.
-fn rolling_mean_stddev_strict_impl(
+pub fn rolling_mean_stddev_strict(
     data: &[Option<f64>],
     period: usize,
 ) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
@@ -252,14 +243,6 @@ fn rolling_mean_stddev_strict_impl(
     }
 
     (means, stddevs)
-}
-
-/// Computes rolling mean and standard deviation for fully valid windows only.
-pub fn rolling_mean_stddev_strict(
-    data: &[Option<f64>],
-    period: usize,
-) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
-    rolling_mean_stddev_strict_impl(data, period)
 }
 
 fn push_max_index(deque: &mut VecDeque<usize>, data: &[f64], idx: usize) {

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -168,21 +168,37 @@ fn rolling_weighted_mean_strict_impl(data: &[Option<f64>], period: usize) -> Vec
     }
 
     let weight_sum = (period * (period + 1)) as f64 / 2.0;
+    let mut sum = 0.0;
+    let mut weighted_sum = 0.0;
+    let mut valid_count = 0usize;
 
-    for end in (period - 1)..len {
-        let start = end + 1 - period;
-        let mut weighted_sum = 0.0;
-        let mut valid = true;
+    for i in 0..period {
+        if let Some(value) = data[i] {
+            sum += value;
+            weighted_sum += value * (i + 1) as f64;
+            valid_count += 1;
+        }
+    }
 
-        for (offset, item) in data[start..=end].iter().enumerate() {
-            let Some(value) = *item else {
-                valid = false;
-                break;
-            };
-            weighted_sum += value * (offset + 1) as f64;
+    if valid_count == period {
+        result[period - 1] = Some(weighted_sum / weight_sum);
+    }
+
+    for end in period..len {
+        let entering = data[end].unwrap_or(0.0);
+        let leaving = data[end - period].unwrap_or(0.0);
+
+        weighted_sum = weighted_sum - sum + entering * period as f64;
+        sum += entering - leaving;
+
+        if data[end].is_some() {
+            valid_count += 1;
+        }
+        if data[end - period].is_some() {
+            valid_count -= 1;
         }
 
-        if valid {
+        if valid_count == period {
             result[end] = Some(weighted_sum / weight_sum);
         }
     }


### PR DESCRIPTION
## 요약
- 이 PR은 `techr-core`의 nullable 입력 마이그레이션을 시작하는 bottom PR입니다.
- 공개 indicator API의 결측치 계약을 `NaN`이 아닌 `&[Option<f64>]` aligned series로 정리하고, 이후 stacked PR인 `#16`, `#17`이 이 규칙 위에서 stateful/composite 지표를 순차적으로 올립니다.
- 범위는 foundation helper와 단일 시계열 기반 지표 중심이며, `plugin/polars`의 실제 nullable adapter 마이그레이션은 이번 스택에서 제외합니다.

## 배경
- 기존 `core` 함수들은 대부분 dense `&[f64]` 입력을 전제하고 있었습니다.
- 하지만 실제 시계열 처리에서는 결측이 섞인 aligned series를 직접 받을 수 있어야 하고, 표준 라이브러리 성격의 API라면 missing을 `NaN`이 아니라 명시적인 타입으로 다루는 편이 계약이 더 분명합니다.
- 이 스택의 목표는 `techr-core` 전체에서 nullable aligned input을 표준 계약으로 만들고, gap을 건너뛰며 series를 압축하지 않는 일관된 의미론을 정착시키는 것입니다.

## 이 PR에서 하는 일
- `core/src/utils.rs`에 nullable rolling/helper primitive를 추가해 foundation semantics를 먼저 고정합니다.
- `sma`, `ema`, `wma`, `bband`, `env`, `disparity`를 `&[Option<f64>]` 입력 기준으로 전환합니다.
- foundation helper를 사용하는 일부 downstream indicator의 public 시그니처도 같은 계약에 맞게 정렬합니다 (`macd`, `ppo`, `pvo`, `massi`, `sonar` 등).
- 공개 API의 결측치 표현으로 `NaN`을 새로 도입하지 않도록 정리합니다.

## 핵심 규칙
- 출력 길이는 입력 정렬을 그대로 유지합니다.
- rolling 계산은 필요한 lookback window 안에 gap이 있으면 해당 row를 `None`으로 반환합니다.
- recursive smoothing은 gap row에서 output만 `None`이고 내부 상태는 유지합니다.
- valid 값만 따로 압축해서 계산한 뒤 다시 원래 위치에 펴는 방식을 public contract로 사용하지 않습니다.

## 범위 외
- `plugin/polars` nullable adapter 마이그레이션은 후속 작업으로 미룹니다.
- 다만 현재 CI에서 `Polars CI`가 core-only PR에도 실행되기 때문에, 이 PR에는 non-polars 변경에서 `validate`를 성공적인 no-op으로 처리하도록 하는 최소한의 workflow 조정이 함께 포함됩니다.
- 이 workflow 변경은 core nullable 전환 자체의 기능 스코프가 아니라, deferred plugin migration이 현재 스택을 막지 않도록 하는 CI 보정입니다.

## 리뷰 가이드
- 먼저 `core/src/utils.rs`, `sma.rs`, `ema.rs`, `wma.rs`, `bband.rs`, `disparity.rs`를 봐주시면 됩니다.
- 그 다음 downstream 시그니처 정렬과 `.github/workflows/polars-ci.yml` 변경을 확인하시면 충분합니다.
- 이 PR만 `main` 기준으로 리뷰하면 되고, 상위 PR인 `#16`, `#17`은 각각 이 PR을 base로 봐주시면 됩니다.

## 테스트 계획
- [x] `cargo fmt --package techr-core --check`
- [x] `cargo test -p techr-core`
- [x] GitHub Actions `Polars CI`가 non-polars 변경에서 성공적으로 통과하는지 확인
