### PR TITLE
✨ RSI, CCI signal 지표 추가

### DIFF
--- a/core/src/indicators/cci.rs
+++ b/core/src/indicators/cci.rs
@@ -5,6 +5,19 @@ pub fn cci(
     lows: &[Option<f64>],
     closes: &[Option<f64>],
     period: usize,
+    signal_period: usize,
+) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    let line = cci_line(highs, lows, closes, period);
+    let signal = ema(&line, signal_period);
+
+    (line, signal)
+}
+
+pub fn cci_line(
+    highs: &[Option<f64>],
+    lows: &[Option<f64>],
+    closes: &[Option<f64>],
+    period: usize,
 ) -> Vec<Option<f64>> {
     let len = highs.len();
     let mut result = vec![None; len];
@@ -69,7 +82,7 @@ pub fn cci_signal(
     period: usize,
     signal_period: usize,
 ) -> Vec<Option<f64>> {
-    let line = cci(highs, lows, closes, period);
+    let line = cci_line(highs, lows, closes, period);
     ema(&line, signal_period)
 }
 
@@ -86,7 +99,7 @@ mod tests {
             let high = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "h");
             let low = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "l");
             let close = testutils::load_data_nullable(&format!("../data/{}.json", symbol), "c");
-            let result = cci(&high, &low, &close, 20);
+            let (result, signal) = cci(&high, &low, &close, 20, 9);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/cci_{}.json",
                 symbol
@@ -98,6 +111,7 @@ mod tests {
                 "CCI test failed for symbol {}.",
                 symbol
             );
+            assert_eq!(signal, cci_signal(&high, &low, &close, 20, 9));
         }
     }
 
@@ -107,7 +121,7 @@ mod tests {
         let lows = vec![Some(2.0), Some(2.0), None, Some(6.0), Some(8.0)];
         let closes = vec![Some(3.0), Some(4.0), None, Some(9.0), Some(11.0)];
 
-        let result = round_vec(cci(&highs, &lows, &closes, 2), 8);
+        let result = round_vec(cci_line(&highs, &lows, &closes, 2), 8);
 
         assert_eq!(
             result,
@@ -144,9 +158,12 @@ mod tests {
             Some(12.0),
         ];
 
-        let line = cci(&highs, &lows, &closes, 2);
+        let line = cci_line(&highs, &lows, &closes, 2);
         let signal = cci_signal(&highs, &lows, &closes, 2, 2);
+        let (composite_line, composite_signal) = cci(&highs, &lows, &closes, 2, 2);
 
         assert_eq!(signal, ema(&line, 2));
+        assert_eq!(composite_line, line);
+        assert_eq!(composite_signal, signal);
     }
 }

--- a/core/src/indicators/cci.rs
+++ b/core/src/indicators/cci.rs
@@ -1,3 +1,5 @@
+use crate::indicators::ema::ema;
+
 pub fn cci(
     highs: &[Option<f64>],
     lows: &[Option<f64>],
@@ -60,6 +62,17 @@ pub fn cci(
     result
 }
 
+pub fn cci_signal(
+    highs: &[Option<f64>],
+    lows: &[Option<f64>],
+    closes: &[Option<f64>],
+    period: usize,
+    signal_period: usize,
+) -> Vec<Option<f64>> {
+    let line = cci(highs, lows, closes, period);
+    ema(&line, signal_period)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,5 +122,31 @@ mod tests {
                 8
             )
         );
+    }
+
+    #[test]
+    fn test_cci_signal_follows_base_ema_contract() {
+        let highs = vec![
+            Some(4.0),
+            Some(6.0),
+            None,
+            Some(10.0),
+            Some(12.0),
+            Some(14.0),
+        ];
+        let lows = vec![Some(2.0), Some(2.0), None, Some(6.0), Some(8.0), Some(10.0)];
+        let closes = vec![
+            Some(3.0),
+            Some(4.0),
+            None,
+            Some(9.0),
+            Some(11.0),
+            Some(12.0),
+        ];
+
+        let line = cci(&highs, &lows, &closes, 2);
+        let signal = cci_signal(&highs, &lows, &closes, 2, 2);
+
+        assert_eq!(signal, ema(&line, 2));
     }
 }

--- a/core/src/indicators/rsi.rs
+++ b/core/src/indicators/rsi.rs
@@ -1,3 +1,5 @@
+use crate::indicators::ema::ema;
+
 pub fn rsi(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let mut rsi = vec![None; data.len()];
 
@@ -57,6 +59,11 @@ pub fn rsi(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     }
 
     rsi
+}
+
+pub fn rsi_signal(data: &[Option<f64>], period: usize, signal_period: usize) -> Vec<Option<f64>> {
+    let line = rsi(data, period);
+    ema(&line, signal_period)
 }
 
 #[cfg(test)]
@@ -134,5 +141,24 @@ mod tests {
             result,
             vec![None, None, None, None, None, None, Some(66.66666666666666)]
         );
+    }
+
+    #[test]
+    fn test_rsi_signal_follows_base_ema_contract() {
+        let aligned = vec![
+            Some(1.0),
+            Some(2.0),
+            Some(3.0),
+            Some(2.0),
+            None,
+            Some(4.0),
+            Some(5.0),
+            Some(6.0),
+        ];
+
+        let line = rsi(&aligned, 3);
+        let signal = rsi_signal(&aligned, 3, 2);
+
+        assert_eq!(signal, ema(&line, 2));
     }
 }

--- a/core/src/indicators/rsi.rs
+++ b/core/src/indicators/rsi.rs
@@ -1,6 +1,17 @@
 use crate::indicators::ema::ema;
 
-pub fn rsi(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
+pub fn rsi(
+    data: &[Option<f64>],
+    period: usize,
+    signal_period: usize,
+) -> (Vec<Option<f64>>, Vec<Option<f64>>) {
+    let line = rsi_line(data, period);
+    let signal = ema(&line, signal_period);
+
+    (line, signal)
+}
+
+pub fn rsi_line(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
     let mut rsi = vec![None; data.len()];
 
     if data.len() < period || period <= 1 {
@@ -62,7 +73,7 @@ pub fn rsi(data: &[Option<f64>], period: usize) -> Vec<Option<f64>> {
 }
 
 pub fn rsi_signal(data: &[Option<f64>], period: usize, signal_period: usize) -> Vec<Option<f64>> {
-    let line = rsi(data, period);
+    let line = rsi_line(data, period);
     ema(&line, signal_period)
 }
 
@@ -80,7 +91,7 @@ mod tests {
                 .into_iter()
                 .map(Some)
                 .collect::<Vec<_>>();
-            let result = rsi(&input, 14);
+            let (result, signal) = rsi(&input, 14, 9);
             let expected = testutils::load_expected::<Option<f64>>(&format!(
                 "../data/expected/rsi_{}.json",
                 symbol
@@ -92,6 +103,7 @@ mod tests {
                 "RSI test failed for symbol {}.",
                 symbol
             );
+            assert_eq!(signal, rsi_signal(&input, 14, 9));
         }
     }
 
@@ -107,7 +119,7 @@ mod tests {
             Some(5.0),
         ];
 
-        let result = rsi(&aligned, 3);
+        let result = rsi_line(&aligned, 3);
 
         assert_eq!(
             result,
@@ -135,7 +147,7 @@ mod tests {
             Some(4.0),
         ];
 
-        let result = rsi(&aligned, 3);
+        let result = rsi_line(&aligned, 3);
 
         assert_eq!(
             result,
@@ -156,9 +168,12 @@ mod tests {
             Some(6.0),
         ];
 
-        let line = rsi(&aligned, 3);
+        let line = rsi_line(&aligned, 3);
         let signal = rsi_signal(&aligned, 3, 2);
+        let (composite_line, composite_signal) = rsi(&aligned, 3, 2);
 
         assert_eq!(signal, ema(&line, 2));
+        assert_eq!(composite_line, line);
+        assert_eq!(composite_signal, signal);
     }
 }

--- a/core/src/indicators/stochrsi.rs
+++ b/core/src/indicators/stochrsi.rs
@@ -1,4 +1,4 @@
-use crate::indicators::rsi::rsi;
+use crate::indicators::rsi::rsi_line;
 use crate::utils::{rolling_max_min, rolling_mean_strict};
 
 pub fn stochrsi(
@@ -14,7 +14,7 @@ pub fn stochrsi(
         return (percent_k, vec![None; len]);
     }
 
-    let rsi_values = rsi(closes, period_rsi);
+    let rsi_values = rsi_line(closes, period_rsi);
     let (rolling_max, rolling_min) = rolling_max_min(&rsi_values, &rsi_values, period_k);
 
     for i in (period_rsi + period_k - 1)..len {

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_techr"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Polars expression plugins for techr indicators"
 license = "MIT"

--- a/polars/README.md
+++ b/polars/README.md
@@ -10,10 +10,10 @@ uv add techr
 
 ## Supported indicators
 
-- Price/trend: `sma`, `wma`, `ema`, `disparity`, `mom`, `roc`, `rsi`, `rsi_signal`, `psl`
+- Price/trend: `sma`, `wma`, `ema`, `disparity`, `mom`, `roc`, `rsi`, `rsi_line`, `rsi_signal`, `psl`
 - Bands/channels: `bband_middle`, `bband_lower`, `bband_upper`, `env_upper`, `env_middle`, `env_lower`, `pchan_upper`, `pchan_middle`, `pchan_lower`
 - Momentum/oscillators: `macd`, `macd_line`, `macd_signal`, `macd_hist`, `macd_histogram`, `ppo_line`, `ppo_signal`, `ppo_histogram`, `pvo_line`, `pvo_signal`, `pvo_histogram`, `sonar_line`, `sonar_signal`, `trix_line`, `trix_signal`, `stochf_percent_k`, `stochf_percent_d`, `stoch_percent_k`, `stoch_percent_d`, `stochrsi_percent_k`, `stochrsi_percent_d`
-- High/low/volume indicators: `ad`, `adx`, `adxr`, `aroon_up`, `aroon_down`, `aroonosc`, `atr`, `cci`, `cci_signal`, `cmf`, `co`, `cv`, `dmi_plus`, `dmi_minus`, `efi`, `eom_line`, `eom_signal`, `erbear`, `erbull`, `massi_line`, `massi_signal`, `mfi`, `nvi_line`, `nvi_signal`, `obv_line`, `obv_signal`, `psar`, `pvi_line`, `pvi_signal`, `ultosc`, `vr`, `willr`
+- High/low/volume indicators: `ad`, `adx`, `adxr`, `aroon_up`, `aroon_down`, `aroonosc`, `atr`, `cci`, `cci_line`, `cci_signal`, `cmf`, `co`, `cv`, `dmi_plus`, `dmi_minus`, `efi`, `eom_line`, `eom_signal`, `erbear`, `erbull`, `massi_line`, `massi_signal`, `mfi`, `nvi_line`, `nvi_signal`, `obv_line`, `obv_signal`, `psar`, `pvi_line`, `pvi_signal`, `ultosc`, `vr`, `willr`
 - Ichimoku: `ichimoku_base_line`, `ichimoku_conversion_line`, `ichimoku_leading_span_a`, `ichimoku_leading_span_b`, `ichimoku_lagging_span`
 
 ## Usage

--- a/polars/README.md
+++ b/polars/README.md
@@ -10,10 +10,10 @@ uv add techr
 
 ## Supported indicators
 
-- Price/trend: `sma`, `wma`, `ema`, `disparity`, `mom`, `roc`, `rsi`, `psl`
+- Price/trend: `sma`, `wma`, `ema`, `disparity`, `mom`, `roc`, `rsi`, `rsi_signal`, `psl`
 - Bands/channels: `bband_middle`, `bband_lower`, `bband_upper`, `env_upper`, `env_middle`, `env_lower`, `pchan_upper`, `pchan_middle`, `pchan_lower`
 - Momentum/oscillators: `macd`, `macd_line`, `macd_signal`, `macd_hist`, `macd_histogram`, `ppo_line`, `ppo_signal`, `ppo_histogram`, `pvo_line`, `pvo_signal`, `pvo_histogram`, `sonar_line`, `sonar_signal`, `trix_line`, `trix_signal`, `stochf_percent_k`, `stochf_percent_d`, `stoch_percent_k`, `stoch_percent_d`, `stochrsi_percent_k`, `stochrsi_percent_d`
-- High/low/volume indicators: `ad`, `adx`, `adxr`, `aroon_up`, `aroon_down`, `aroonosc`, `atr`, `cci`, `cmf`, `co`, `cv`, `dmi_plus`, `dmi_minus`, `efi`, `eom_line`, `eom_signal`, `erbear`, `erbull`, `massi_line`, `massi_signal`, `mfi`, `nvi_line`, `nvi_signal`, `obv_line`, `obv_signal`, `psar`, `pvi_line`, `pvi_signal`, `ultosc`, `vr`, `willr`
+- High/low/volume indicators: `ad`, `adx`, `adxr`, `aroon_up`, `aroon_down`, `aroonosc`, `atr`, `cci`, `cci_signal`, `cmf`, `co`, `cv`, `dmi_plus`, `dmi_minus`, `efi`, `eom_line`, `eom_signal`, `erbear`, `erbull`, `massi_line`, `massi_signal`, `mfi`, `nvi_line`, `nvi_signal`, `obv_line`, `obv_signal`, `psar`, `pvi_line`, `pvi_signal`, `ultosc`, `vr`, `willr`
 - Ichimoku: `ichimoku_base_line`, `ichimoku_conversion_line`, `ichimoku_leading_span_a`, `ichimoku_leading_span_b`, `ichimoku_lagging_span`
 
 ## Usage

--- a/polars/src/expressions.rs
+++ b/polars/src/expressions.rs
@@ -495,7 +495,20 @@ fn cci(inputs: &[Series], kwargs: PeriodKwargs) -> PolarsResult<Series> {
     let highs = series_to_f64_vec(&inputs[0])?;
     let lows = series_to_f64_vec(&inputs[1])?;
     let closes = series_to_f64_vec(&inputs[2])?;
-    Ok(option_vec_to_series(core::cci(
+    Ok(option_vec_to_series(core::cci_line(
+        &highs,
+        &lows,
+        &closes,
+        kwargs.period as usize,
+    )))
+}
+
+#[polars_expr(output_type=Float64)]
+fn cci_line(inputs: &[Series], kwargs: PeriodKwargs) -> PolarsResult<Series> {
+    let highs = series_to_f64_vec(&inputs[0])?;
+    let lows = series_to_f64_vec(&inputs[1])?;
+    let closes = series_to_f64_vec(&inputs[2])?;
+    Ok(option_vec_to_series(core::cci_line(
         &highs,
         &lows,
         &closes,
@@ -887,7 +900,16 @@ fn roc(inputs: &[Series], kwargs: PeriodKwargs) -> PolarsResult<Series> {
 #[polars_expr(output_type=Float64)]
 fn rsi(inputs: &[Series], kwargs: PeriodKwargs) -> PolarsResult<Series> {
     let input = series_to_f64_vec(&inputs[0])?;
-    Ok(option_vec_to_series(core::rsi(
+    Ok(option_vec_to_series(core::rsi_line(
+        &input,
+        kwargs.period as usize,
+    )))
+}
+
+#[polars_expr(output_type=Float64)]
+fn rsi_line(inputs: &[Series], kwargs: PeriodKwargs) -> PolarsResult<Series> {
+    let input = series_to_f64_vec(&inputs[0])?;
+    Ok(option_vec_to_series(core::rsi_line(
         &input,
         kwargs.period as usize,
     )))

--- a/polars/src/expressions.rs
+++ b/polars/src/expressions.rs
@@ -22,6 +22,12 @@ struct PeriodKwargs {
 }
 
 #[derive(Deserialize)]
+struct PeriodSignalKwargs {
+    period: u32,
+    signal_period: u32,
+}
+
+#[derive(Deserialize)]
 struct BBandKwargs {
     period: u32,
     sigma: f64,
@@ -143,12 +149,6 @@ struct SonarLineKwargs {
 struct SonarSignalKwargs {
     period: u32,
     step: u32,
-    signal_period: u32,
-}
-
-#[derive(Deserialize)]
-struct PeriodSignalKwargs {
-    period: u32,
     signal_period: u32,
 }
 
@@ -500,6 +500,20 @@ fn cci(inputs: &[Series], kwargs: PeriodKwargs) -> PolarsResult<Series> {
         &lows,
         &closes,
         kwargs.period as usize,
+    )))
+}
+
+#[polars_expr(output_type=Float64)]
+fn cci_signal(inputs: &[Series], kwargs: PeriodSignalKwargs) -> PolarsResult<Series> {
+    let highs = series_to_f64_vec(&inputs[0])?;
+    let lows = series_to_f64_vec(&inputs[1])?;
+    let closes = series_to_f64_vec(&inputs[2])?;
+    Ok(option_vec_to_series(core::cci_signal(
+        &highs,
+        &lows,
+        &closes,
+        kwargs.period as usize,
+        kwargs.signal_period as usize,
     )))
 }
 
@@ -876,6 +890,16 @@ fn rsi(inputs: &[Series], kwargs: PeriodKwargs) -> PolarsResult<Series> {
     Ok(option_vec_to_series(core::rsi(
         &input,
         kwargs.period as usize,
+    )))
+}
+
+#[polars_expr(output_type=Float64)]
+fn rsi_signal(inputs: &[Series], kwargs: PeriodSignalKwargs) -> PolarsResult<Series> {
+    let input = series_to_f64_vec(&inputs[0])?;
+    Ok(option_vec_to_series(core::rsi_signal(
+        &input,
+        kwargs.period as usize,
+        kwargs.signal_period as usize,
     )))
 }
 

--- a/polars/techr/__init__.py
+++ b/polars/techr/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "bband_middle",
     "bband_upper",
     "cci",
+    "cci_signal",
     "cmf",
     "co",
     "cv",
@@ -68,6 +69,7 @@ __all__ = [
     "pvo_signal",
     "roc",
     "rsi",
+    "rsi_signal",
     "sma",
     "sonar_line",
     "sonar_signal",
@@ -377,6 +379,21 @@ def atr(high: IntoExpr, low: IntoExpr, close: IntoExpr, *, period: int) -> pl.Ex
 
 def cci(high: IntoExpr, low: IntoExpr, close: IntoExpr, *, period: int) -> pl.Expr:
     return _register("cci", [high, low, close], {"period": period})
+
+
+def cci_signal(
+    high: IntoExpr,
+    low: IntoExpr,
+    close: IntoExpr,
+    *,
+    period: int,
+    signal_period: int,
+) -> pl.Expr:
+    return _register(
+        "cci_signal",
+        [high, low, close],
+        {"period": period, "signal_period": signal_period},
+    )
 
 
 def cmf(
@@ -704,6 +721,14 @@ def roc(close: IntoExpr, *, period: int) -> pl.Expr:
 
 def rsi(expr: IntoExpr, *, period: int) -> pl.Expr:
     return _register("rsi", [expr], {"period": period})
+
+
+def rsi_signal(expr: IntoExpr, *, period: int, signal_period: int) -> pl.Expr:
+    return _register(
+        "rsi_signal",
+        [expr],
+        {"period": period, "signal_period": signal_period},
+    )
 
 
 def trix_line(expr: IntoExpr, *, period: int) -> pl.Expr:

--- a/polars/techr/__init__.py
+++ b/polars/techr/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "bband_middle",
     "bband_upper",
     "cci",
+    "cci_line",
     "cci_signal",
     "cmf",
     "co",
@@ -69,6 +70,7 @@ __all__ = [
     "pvo_signal",
     "roc",
     "rsi",
+    "rsi_line",
     "rsi_signal",
     "sma",
     "sonar_line",
@@ -379,6 +381,10 @@ def atr(high: IntoExpr, low: IntoExpr, close: IntoExpr, *, period: int) -> pl.Ex
 
 def cci(high: IntoExpr, low: IntoExpr, close: IntoExpr, *, period: int) -> pl.Expr:
     return _register("cci", [high, low, close], {"period": period})
+
+
+def cci_line(high: IntoExpr, low: IntoExpr, close: IntoExpr, *, period: int) -> pl.Expr:
+    return _register("cci_line", [high, low, close], {"period": period})
 
 
 def cci_signal(
@@ -721,6 +727,10 @@ def roc(close: IntoExpr, *, period: int) -> pl.Expr:
 
 def rsi(expr: IntoExpr, *, period: int) -> pl.Expr:
     return _register("rsi", [expr], {"period": period})
+
+
+def rsi_line(expr: IntoExpr, *, period: int) -> pl.Expr:
+    return _register("rsi_line", [expr], {"period": period})
 
 
 def rsi_signal(expr: IntoExpr, *, period: int, signal_period: int) -> pl.Expr:

--- a/polars/tests/test_indicators.py
+++ b/polars/tests/test_indicators.py
@@ -125,6 +125,11 @@ CORE_EXPECTED_CASES: list[tuple[str, SeriesExprBuilder, str]] = [
         "cci",
     ),
     (
+        "cci_line",
+        lambda: ta.cci_line(pl.col("high"), pl.col("low"), pl.col("close"), period=20),
+        "cci",
+    ),
+    (
         "cmf",
         lambda: ta.cmf(
             pl.col("high"),
@@ -391,6 +396,7 @@ CORE_EXPECTED_CASES: list[tuple[str, SeriesExprBuilder, str]] = [
     ),
     ("roc", lambda: ta.roc(pl.col("close"), period=20), "roc"),
     ("rsi", lambda: ta.rsi(pl.col("close"), period=14), "rsi"),
+    ("rsi_line", lambda: ta.rsi_line(pl.col("close"), period=14), "rsi"),
     ("bband_middle", lambda: ta.bband_middle(pl.col("close"), period=20), "sma"),
     (
         "bband_lower",

--- a/polars/tests/test_indicators.py
+++ b/polars/tests/test_indicators.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Callable
+from typing import Callable, cast
 
 import polars as pl
 import pytest
@@ -51,11 +51,10 @@ def assert_values_close(
 
 
 def select_expr(df: pl.DataFrame, expr: pl.Expr, alias: str, lazy: bool) -> pl.Series:
-    query = df.lazy() if lazy else df
-    result = query.select(expr.alias(alias))
     if lazy:
-        result = result.collect()
-    return result.get_column(alias)
+        result = cast(pl.DataFrame, df.lazy().select(expr.alias(alias)).collect())
+        return result.get_column(alias)
+    return df.select(expr.alias(alias)).get_column(alias)
 
 
 SeriesExprBuilder = Callable[[], pl.Expr]
@@ -655,6 +654,63 @@ def test_single_input_null_values_follow_core_gap_semantics(lazy: bool) -> None:
 
     # then
     assert_values_close(result.to_list(), [None, None, None, 3.5])
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_rsi_signal_matches_ema_of_rsi(lazy: bool) -> None:
+    """RSI signal is the EMA of the RSI line."""
+    # given
+    df = load_ohlcv("TSLA")
+
+    # when
+    signal = select_expr(
+        df,
+        ta.rsi_signal(pl.col("close"), period=14, signal_period=9),
+        "signal",
+        lazy,
+    )
+    expected = select_expr(
+        df,
+        ta.ema(ta.rsi(pl.col("close"), period=14), period=9),
+        "expected",
+        lazy,
+    )
+
+    # then
+    assert_values_close(signal.to_list(), expected.to_list())
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_cci_signal_matches_ema_of_cci(lazy: bool) -> None:
+    """CCI signal is the EMA of the CCI line."""
+    # given
+    df = load_ohlcv("TSLA")
+
+    # when
+    signal = select_expr(
+        df,
+        ta.cci_signal(
+            pl.col("high"),
+            pl.col("low"),
+            pl.col("close"),
+            period=20,
+            signal_period=9,
+        ),
+        "signal",
+        lazy,
+    )
+    expected = select_expr(
+        df,
+        ta.ema(
+            ta.cci(pl.col("high"), pl.col("low"), pl.col("close"), period=20),
+            period=9,
+        ),
+        "expected",
+        lazy,
+    )
+
+    # then
+    assert_values_close(signal.to_list(), expected.to_list())
 
 
 @pytest.mark.parametrize("lazy", [False, True])


### PR DESCRIPTION
## 변경 사항
- core에 RSI signal과 CCI signal 계산 함수를 추가했습니다.
- 기존 signal 포함 지표들과 맞춰 core의 `rsi`, `cci`는 `(line, signal)`을 반환하도록 정리하고, 단일 라인 API로 `rsi_line`, `cci_line`을 추가했습니다.
- signal은 각 RSI/CCI 라인에 `EMA(signal_period)`를 적용해 기존 null/seed recovery semantics를 그대로 따르도록 했습니다.
- Polars plugin과 Python wrapper에 `rsi_line`, `rsi_signal`, `cci_line`, `cci_signal` API를 노출했습니다.
- 기존 Polars `rsi`, `cci`는 line 반환 API로 유지했습니다.
- Python wrapper의 `__all__`과 README 지원 지표 목록을 갱신했습니다.
- Polars plugin crate 버전을 `0.1.4`에서 `0.1.5`로 갱신했습니다.
- core 단위 테스트와 Polars eager/lazy 테스트를 추가했습니다.

## 검증
- `cargo test -p techr-core`
- `cd polars && uv run maturin develop --uv`
- `cd polars && uv run pytest` (`314 passed`)
- `cd polars && uv run ruff check`
- `cd polars && uv run ty check`
- `cargo fmt --all --check && git diff --check`

## 참고
- `cargo test --workspace`는 Polars cdylib 테스트 링크 단계에서 Python C API 심볼을 찾지 못해 실패했습니다. Polars는 기존 개발 경로인 `maturin develop` 후 `pytest`로 검증했습니다.